### PR TITLE
商品詳細ページのマークアップ 

### DIFF
--- a/app/assets/javascripts/item_informations.coffee
+++ b/app/assets/javascripts/item_informations.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/item_informations.coffee
+++ b/app/assets/javascripts/item_informations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -13,3 +13,8 @@ a {
   flex-direction: column;
   min-height: 100vh;
 }
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -8,7 +8,7 @@ a {
 }
 
 .wrapper {
-  background-color: $whitesmoke;
+  background-color: whitesmoke;
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -17,4 +17,8 @@ a {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+}
+
+body {
+  font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,10 @@
 @import "font-awesome";
 @import "config/reset";
 @import "config/color";
+@import "item_informations/main-content";
 @import "common";
 @import "tops/header";
 @import "tops/main-content";
 @import "tops/footer";
+@import "mixin/clearfix";
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,5 +7,3 @@
 @import "tops/header";
 @import "tops/main-content";
 @import "tops/footer";
-@import "mixin/clearfix";
-

--- a/app/assets/stylesheets/config/_color.scss
+++ b/app/assets/stylesheets/config/_color.scss
@@ -1,4 +1,6 @@
-$white: rgb(255,255,255);
+$background-white: rgb(255,255,255);
 $box-shadow-black: rgba(0, 0, 0, 0.18);
-$whitesmoke: rgb(245, 245, 245);
+$border-line: rgb(245, 245, 245);
 $whitegray: rgb(204, 204, 204);
+$link-color: rgb(0, 153 ,232);
+$like-icon: rgb(234, 53, 45);

--- a/app/assets/stylesheets/item_informations/_main-content.scss
+++ b/app/assets/stylesheets/item_informations/_main-content.scss
@@ -101,7 +101,6 @@
   height: 420px;
   margin: 0 auto;
   width: 100%;
-  /*隣接するボーダーを重ねて表示*/
   border-collapse: collapse;
   border: 1px solid $border-line;
 
@@ -183,7 +182,6 @@
     padding: 8px;
     border-radius: 4px;
     
-    /*吹き出し*/
     &:after {
       content: '';
       position: absolute;
@@ -327,7 +325,6 @@
           max-width: 100%;
           height: 1.2em;
           white-space: nowrap;
-          /*不要？f*/
           text-overflow: ellipsis;
         }
       }

--- a/app/assets/stylesheets/item_informations/_main-content.scss
+++ b/app/assets/stylesheets/item_informations/_main-content.scss
@@ -303,10 +303,6 @@
           height: 40px;
           overflow: hidden;
           border-radius: 50%;
-          border-top-left-radius: 50%;
-          border-top-right-radius: 50%;
-          border-bottom-right-radius: 50%;
-          border-bottom-left-radius: 50%;
         }
 
         &__unknown {

--- a/app/assets/stylesheets/item_informations/_main-content.scss
+++ b/app/assets/stylesheets/item_informations/_main-content.scss
@@ -1,0 +1,853 @@
+.item-box-container {
+  padding: 24px 40px 40px;
+  background: #fff;
+  margin: 40px auto 0;
+  width: 700px;
+
+}
+
+.item-name {
+  font-size: 24px;
+  text-align: center;
+  word-wrap: break-word;
+  line-height: 1.4;
+  font-weight: bold;
+}
+
+.clearfix:after {
+  content: '';
+  display: block;
+  clear: both;
+}
+
+.item-photo {
+  float: left;
+  min-width: 300px;
+  max-width: 300px;
+  min-height: 375px;
+  position: relative;
+  margin: 0 auto;
+
+  &__list {
+    position: relative;
+
+    &__outer {
+      position: relative;
+      overflow: hidden;
+
+      &-stage {
+        position: relative;
+        left: 0;
+        width: 1200px;
+
+        &__item {
+          width: 300px;
+          min-height: 1px;
+          float: left;
+          user-select: none;
+          -webkit-tap-highlight-color: transparent;
+          -webkit-touch-callout: none;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+
+          &-inner {
+            position: relative;
+            width: 100%;
+            height: 0;
+            padding: 0 0 100%;
+
+            &__lazy {
+              transition: opacity 400ms ease;
+              width: 100%;
+              vertical-align: bottom;
+              opacity: 1;
+            }
+          }
+        }
+      }
+
+      &__dots {
+        line-height: 0;
+
+        &__dot {
+          width: 60px;
+          height: 60px;
+          max-height: none;
+          position: relative;
+          overflow: hidden;
+          display: inline-block;
+          width: 20%;
+          max-height: 90px;
+          opacity: .4;
+          cursor: pointer;
+
+          &.active {
+            opacity: 1;
+            cursor: default;
+          }
+
+          & span {
+            display: none;
+          }
+
+          &__inner {
+            position:static;
+            width: auto;
+            height: auto;
+            padding: 0;
+            overflow: hidden;
+            pointer-events: none;
+
+            & img {
+              width: 100%;
+              vertical-align: bottom;
+              
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+.item-detail-table {
+  float: right;
+  max-width: 300px;
+  height: 420px;
+  margin: 0 auto;
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #f5f5f5;
+
+  & th {
+    width: 39%;
+    text-align: center;
+    font-weight: 400;
+    background: #fafafa;
+    padding: 8px;
+    border-collapse: collapse;
+    border: 1px solid #f5f5f5;
+  }
+
+  & td {
+    width: 61%;
+    background: #fff;
+    padding: 8px;
+    border-collapse: collapse;
+    border: 1px solid #f5f5f5;
+
+    & a {
+      color: #0099e8;
+      text-decoration: none;
+    }
+  }
+}
+
+.item-user-ratings {
+  display: inline-block;
+  margin: 8px 0 0 16px;
+
+  &:first-child {
+    margin: 0;
+  }
+
+  & i {
+    font-size: 16px;
+    vertical-align: middle;
+  }
+
+  & span {
+    vertical-align: middle;
+    font-size: 10px;
+  }
+}
+
+.item-price-box {
+  margin: 24px 0 0;
+  text-align: center;
+
+  &__bold {
+    margin-right: 16px;
+    font-size: 50px;
+    font-weight: 600;
+  }
+
+  &__tax {
+    font-size: 10px;
+  }
+
+  &__fee {
+    display: inline-block;
+    font-size: 16px;
+  }
+}
+
+.text-center {
+  text-align: center;
+  
+  &__sales-point-message {
+    display: inline-block;
+    position: relative;
+    line-height: 1.5;
+    color: #fff;
+    background: #05B0B4;
+    margin-top: 20px 0 0 0;
+    padding: 8px;
+    border-radius: 4px;
+
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: -10px;
+      left: 50%;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 10px 7.5px 0 7.5px;
+      border-color: #05B0B4 transparent transparent transparent;
+    }
+  }
+}
+
+.item-buy-btn {
+  font-size: 24px;
+  line-height: 60px;
+  display: block;
+  margin-top: 16px;
+  background: #ea352d;
+  color: #fff;
+  text-align: center;
+  font-weight: 600;
+  transition: all ease-out .3s;
+}
+
+.item-description {
+  padding: 32px 0 0;
+  line-height: 1.5;
+  font-size: 18px;
+
+  &__inner {
+    white-space: pre-wrap;
+  }
+}
+
+.item-button-container {
+  margin: 16px 0 0;
+  font-size: 0;
+
+  &.clearfix:after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+
+  &__left {
+    float: left;
+
+    &__like {
+      border: 1px solid #ea352d;
+      background: none;
+      color: #ea352d;
+      /*まとめる*/
+      display: inline-block;
+      padding: 8px 16px;
+      border-radius: 40px;
+      transition: all ease-out .3s;
+    }
+
+    &__report {
+      margin: 0 0 0 16px;
+      color: #333;
+      background: #f5f5f5;
+      /*まとめる*/
+      display: inline-block;
+      padding: 8px 16px;
+      border-radius: 40px;
+      transition: all ease-out .3s;
+    }
+  }
+
+  &__right {
+    margin: 8px 0 0;
+    float: right;
+
+    &__relief {
+      display: inline-block;
+      color: #0099e8;
+    }
+  }
+
+  & i {
+    font-size: 14px;
+    vertical-align: middle;
+  }
+
+  & span {
+    font-size: 14px;
+    margin: 1px 0 0 8px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+}
+
+.item-detail-message {
+  width: 700px;
+  margin: 8px auto;
+
+  &__container__content {
+    padding: 24px;
+    background: #fff;
+
+    &__items {
+      margin: 0;
+
+      & li {
+        margin: 60px 0 0;
+
+        &:first-child {
+          margin: 1.5em 0 0;
+        }
+      }
+
+      &__message-user {
+        float: left;
+        position: relative;
+        top: -20px;
+        display: inline-block;
+        color: #333;
+
+        & figure>div {
+          width: 40px;
+          height: 40px;
+          overflow: hidden;
+          border-radius: 50%;
+          border-top-left-radius: 50%;
+          border-top-right-radius: 50%;
+          border-bottom-right-radius: 50%;
+          border-bottom-left-radius: 50%;
+        }
+
+        &__unknown {
+          background: #eee;
+          text-align: center;
+
+          & img {
+            width: 32px;
+            height: 32px;
+            margin: 10px 0 0;
+            vertical-align: bottom;
+          }
+        }
+
+        & figcaption {
+          width: 600;
+          min-width: 600px;
+          overflow: hidden;
+          position: absolute;
+          top: 0;
+          left: 56px;
+          max-width: 100%;
+          height: 1.2em;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+      }
+
+      &__message-body {
+        width: 600px;
+        float: right;
+        position: relative;
+        padding: 16px;
+        background: #eef0f4;
+        border-radius: 15px;
+        line-height: 1.5;
+        word-break: break-all;
+      }
+
+      &__message-icons {
+        margin: 8px 0 0;
+
+        & time {
+          display: block;
+          color: #aaa;
+        }
+
+        &__icon-left {
+          float: left;
+        }
+
+        & i {
+          vertical-align: middle;
+        }
+
+        & span {
+          vertical-align: middle;
+        }
+      }
+    }
+  }
+}
+
+
+.message-form  {
+  margin: 8px 0 0;
+
+  & p {
+    padding: 8px;
+    font-size: 14px;
+    background: #fff6de;
+  }
+
+  &__textarea-default {
+    display: block;
+    margin: 8px 0 0;
+    width: 100%;
+    max-width: 100%;
+    min-height: 104px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    background: #fff;
+    font-size: 16px;
+    line-height: 1.5;
+    border-radius: 0;
+    outline: 0;
+  }
+
+  &__submit {
+    width: 100%;
+    margin: 8px 0 0;
+    font-size: 0;
+    text-align: center;
+    background: #aaa;
+    border: 1px solid #aaa;
+    color: #fff;
+    display: block;
+    line-height: 48px;
+    transition: all ease-out .3s;
+    cursor: pointer;
+
+    & span {
+      font-size: 14px;
+      vertical-align: middle;
+    }
+  }
+}
+
+.nav-item-link-prev-next {
+  margin: 24px auto 0;
+  width: 700px;
+
+  &clearfix:after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+
+  & .nav-item-link-prev {
+    width: 45%;
+    position: relative;
+    word-wrap: break-word;
+    float: left;
+    padding: 0 0 0 14px;
+    
+    & a {
+      color: #0099e8;
+      font-size: 13px;
+    }
+  }
+
+  & .nav-item-link-next {
+    width: 45%;
+    position: relative;
+    word-wrap: break-word;
+    float: right;
+    padding: 0 14px 0 0;
+    text-align: right;
+
+    & a {
+      color: #0099e8;
+      font-size: 13px;
+    }
+  }
+}
+
+.item-social-media-box {
+  margin: 24px auto;
+  padding: 32px 0 24px;
+  width: 700px;
+  background: #fff;
+
+  &__text-center {
+    text-align: center;
+
+    &__social-media-box {
+      margin: 16px 0 0;
+      text-align: center;
+      font-size: 0;
+
+      & li {
+        display: inline-block;
+        margin: 0 8px 8px 0;
+        vertical-align: middle;
+        text-align: center;
+
+        & a {
+          display: block;
+
+          & i {
+            width: 44px;
+            height: 44px;
+            border-radius: 4px;
+            line-height: 44px;
+          }
+        }
+      }
+    }
+  }
+}
+
+.items-in-user-profile {
+  width: 700px;
+  margin: 0 auto;
+
+  &__items-box-head {
+    font-size: 22px;
+    margin: 24px 0 8px;
+    line-height: 1.4;
+
+    & a {
+      color: #0099e8;
+      text-decoration: none;
+    }
+  }
+
+  &__items-box-content {
+    width: auto;
+    margin: 0 auto;
+
+    &.clearfix:after {
+      content: '';
+      display: block;
+      clear: both;
+    }
+
+    &__item-box {
+      width: 220px;
+      margin: 0 20px 20px 0;
+      position: relative;
+      float: left;
+      background: #fff;
+
+      &:nth-child(3n) {
+        margin-right: 0;
+      }
+      &:nth-child(4n) {
+        margin-right: 20px;
+      }
+      & a {
+        display: block;
+        color: #333;
+      }
+
+      &__photo {
+        width: 220px;
+        height: 220px;
+        overflow: hidden;
+        position: relative;
+        padding: 0 0 100%;
+
+        &__lazyloaded {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 1;
+          width: 100%;
+          opacity: 1;
+          transition: opacity .3s;
+          vertical-align: middle;
+        }
+      }
+    }
+
+    &__body {
+      padding: 16px;
+      height: 110px;
+    }
+
+    &__name {
+      overflow: hidden;
+      position: relative;
+      font-weight: 400;
+      height: 3em;
+      line-height: 1.5;
+      word-break: break-word;
+      white-space: normal;
+      font-size: 16px;
+      color: #333;
+    }
+
+    &__num {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 8px 0 0;
+
+      &__price {
+        font-size: 17px;
+        font-weight: 600;
+        color: #333;
+      }
+
+      &__like {
+        font-size: 16px;
+        font-weight: 400;
+        color: #333;
+
+      }
+    }
+  }
+}
+
+.items-in-user-profile .related-item-column:last-of-type {
+  margin-bottom: 40px;
+}
+
+.items-box-head {
+  font-size: 22px;
+  margin: 24px 0 8px;
+  line-height: 1.4;
+
+  & a {
+    color: #0099e8;
+  }
+
+  &-content {
+    width: auto;
+    margin: 0 auto;
+
+    &.clearfix:after  {
+      content: '';
+      display: block;
+      clear: both;
+    }
+
+    &__item-box {
+      width: 220px;
+      margin: 0 20px 20px 0;
+      position: relative;
+      float: left;
+      background: #fff;
+
+      &:nth-child(3n) {
+        margin-right: 0;
+      }
+
+      &__photo {
+        width: 220px;
+        height: 220px;
+        overflow: hidden;
+        position: relative;
+        padding: 0 0 100%;
+
+        &__lazyloaded {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 1;
+          width: 100%;
+          opacity: 1;
+          transition: opacity .3s;
+        }
+      }
+    }
+  }
+}
+
+.items-box-body {
+  padding: 16px;
+  height: 110px;
+
+  &__name {
+    overflow: hidden;
+    position: relative;
+    font-weight: 400;
+    height: 3em;
+    line-height: 1.5;
+    word-break: break-word;
+    white-space: normal;
+    font-size: 16px;
+    color: #333;
+
+    &:after {
+      display: block;
+      content: '';
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 50%;
+      height: 1.5em;
+      background: linear-gradient(to right, rgba(255,255,255,0), #fff 72%);
+    }
+  }
+
+  &__num {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 8px 0 0;
+
+    &__price {
+      font-size: 17px;
+      font-weight: 600;
+      color: #333;
+    }
+  }
+}
+
+.pos-bottom {
+  background: #f5f5f5;
+  box-shadow: none;
+  position: relative;
+  border-top: 1px solid #eee;
+
+  & ul {
+    width: 1020px;
+    overflow: visible;
+    margin: 0 auto;
+    padding: 16px 0;
+    white-space: normal;
+    font-size: 0;
+
+    & li {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: inline-block;
+      font-size: 14px;
+      line-height: 1.2;
+
+      & a {
+        color: #333;
+      }
+
+      & .icon-arrow-right {
+        margin: 0 8px;
+        font-size: 9px;
+        color: #888;
+      }
+
+      &:last-child {
+        font-weight: 600;
+
+      }
+    }
+  }
+}
+
+
+.owl-carousel .owl-nav {
+  display: none;
+}
+ 
+.owl-nav.disabled .owl-prev, .owl-nav.disabled .owl-next {
+  display: none;
+}
+
+.owl-nav.disabled .owl-prev, .owl-nav.disabled .owl-next {
+  display: none;
+}
+
+.icon-good {
+color: #ef5185;
+}
+
+.icon-normal {
+  color: #fba933;
+}
+
+.icon-bad {
+  color: #6ab5d8;
+}
+
+.icon-like {
+  color: #ea352d;
+}
+
+.icon-lock {
+  color: #0099e8;
+}
+
+.bold {
+  font-weight: 600;
+}
+
+.icon-time {
+  font-size: 16px;
+  vertical-align: middle;
+}
+
+.icon-arrow-left {
+  left: 0;
+  position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
+  color: #0099e8;
+}
+
+.icon-facebook {
+  font-size: 26px;
+  color: #fff;
+  background: #385185;
+}
+
+.icon-twitter {
+  font-size: 26px;
+  color: #fff;
+  background: #5d9dc9;
+}
+
+.icon-pinterest {
+  color: #fff;
+  background: #aa262a;
+  font-size: 18px;
+}
+
+.icon-like-border {
+  color: #ccc;
+}
+
+.icon-balloon {
+  position: absolute;
+  top: 8px;
+  left: -9px;
+  color: #eef0f4;
+  font-size: 15px;
+
+  &::before {
+    content: "";
+    display: inline-block;
+    position: absolute;
+    top: 3px; 
+    left: -10px;
+    border: 8px solid transparent;
+    border-right: 18px solid #edf1ee;
+    -webkit-transform: rotate(35deg);
+    transform: rotate(35deg);
+  }
+}
+
+
+figure {
+  margin: 0;
+  padding: 0;
+}
+
+
+
+
+
+

--- a/app/assets/stylesheets/item_informations/_main-content.scss
+++ b/app/assets/stylesheets/item_informations/_main-content.scss
@@ -331,6 +331,7 @@
           max-width: 100%;
           height: 1.2em;
           white-space: nowrap;
+          /*不要？f*/
           text-overflow: ellipsis;
         }
       }
@@ -423,7 +424,7 @@
     position: relative;
     word-wrap: break-word;
     float: left;
-    padding: 0 0 0 14px;
+    padding-bottom: 14px;
     
     & a {
       color: $link-color;
@@ -436,7 +437,7 @@
     position: relative;
     word-wrap: break-word;
     float: right;
-    padding: 0 14px 0 0;
+    padding-right: 14px;
     text-align: right;
 
     & a {
@@ -745,9 +746,6 @@ color: #ef5185;
 
 .icon-arrow-left {
   left: 0;
-  position: absolute;
-  top: 50%;
-  transform: translate(0, -50%);
   color: $link-color;
 }
 

--- a/app/assets/stylesheets/item_informations/_main-content.scss
+++ b/app/assets/stylesheets/item_informations/_main-content.scss
@@ -1,23 +1,20 @@
 .item-box-container {
   padding: 24px 40px 40px;
-  background: #fff;
+  background: $background-white;
   margin: 40px auto 0;
   width: 700px;
 
-}
+  &__item-name {
+    font-size: 24px;
+    text-align: center;
+    word-wrap: break-word;
+    line-height: 1.4;
+    font-weight: bold;
+  }
 
-.item-name {
-  font-size: 24px;
-  text-align: center;
-  word-wrap: break-word;
-  line-height: 1.4;
-  font-weight: bold;
-}
-
-.clearfix:after {
-  content: '';
-  display: block;
-  clear: both;
+  & .item-main-content {
+    margin: 16px 0 0;
+  }
 }
 
 .item-photo {
@@ -27,6 +24,7 @@
   min-height: 375px;
   position: relative;
   margin: 0 auto;
+  background: #fafafa;
 
   &__list {
     position: relative;
@@ -44,12 +42,6 @@
           width: 300px;
           min-height: 1px;
           float: left;
-          user-select: none;
-          -webkit-tap-highlight-color: transparent;
-          -webkit-touch-callout: none;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
 
           &-inner {
             position: relative;
@@ -58,7 +50,6 @@
             padding: 0 0 100%;
 
             &__lazy {
-              transition: opacity 400ms ease;
               width: 100%;
               vertical-align: bottom;
               opacity: 1;
@@ -87,22 +78,15 @@
             cursor: default;
           }
 
-          & span {
-            display: none;
-          }
-
           &__inner {
-            position:static;
             width: auto;
             height: auto;
             padding: 0;
             overflow: hidden;
-            pointer-events: none;
 
             & img {
               width: 100%;
               vertical-align: bottom;
-              
             }
           }
         }
@@ -117,29 +101,32 @@
   height: 420px;
   margin: 0 auto;
   width: 100%;
+  /*隣接するボーダーを重ねて表示*/
   border-collapse: collapse;
-  border: 1px solid #f5f5f5;
+  border: 1px solid $border-line;
 
   & th {
     width: 39%;
-    text-align: center;
+    text-align: left;
     font-weight: 400;
     background: #fafafa;
-    padding: 8px;
     border-collapse: collapse;
-    border: 1px solid #f5f5f5;
+    padding: 8px;
+    border: 1px solid $border-line;
+
   }
 
   & td {
     width: 61%;
-    background: #fff;
+    background: $background-white;
     padding: 8px;
     border-collapse: collapse;
-    border: 1px solid #f5f5f5;
+    border: 1px solid $border-line;
+
+
 
     & a {
-      color: #0099e8;
-      text-decoration: none;
+      color: $link-color;
     }
   }
 }
@@ -159,7 +146,7 @@
 
   & span {
     vertical-align: middle;
-    font-size: 10px;
+    font-size: 13px;
   }
 }
 
@@ -170,7 +157,7 @@
   &__bold {
     margin-right: 16px;
     font-size: 50px;
-    font-weight: 600;
+    font-weight: 400;
   }
 
   &__tax {
@@ -195,7 +182,8 @@
     margin-top: 20px 0 0 0;
     padding: 8px;
     border-radius: 4px;
-
+    
+    /*吹き出し*/
     &:after {
       content: '';
       position: absolute;
@@ -219,7 +207,6 @@
   color: #fff;
   text-align: center;
   font-weight: 600;
-  transition: all ease-out .3s;
 }
 
 .item-description {
@@ -236,35 +223,26 @@
   margin: 16px 0 0;
   font-size: 0;
 
-  &.clearfix:after {
-    content: '';
-    display: block;
-    clear: both;
-  }
-
   &__left {
     float: left;
 
     &__like {
-      border: 1px solid #ea352d;
+      border: 1px solid $like-icon;
       background: none;
-      color: #ea352d;
-      /*まとめる*/
+      color: $like-icon;
       display: inline-block;
       padding: 8px 16px;
       border-radius: 40px;
-      transition: all ease-out .3s;
+      cursor: pointer;
     }
 
     &__report {
       margin: 0 0 0 16px;
       color: #333;
       background: #f5f5f5;
-      /*まとめる*/
       display: inline-block;
       padding: 8px 16px;
       border-radius: 40px;
-      transition: all ease-out .3s;
     }
   }
 
@@ -274,7 +252,7 @@
 
     &__relief {
       display: inline-block;
-      color: #0099e8;
+      color: $link-color;
     }
   }
 
@@ -297,7 +275,11 @@
 
   &__container__content {
     padding: 24px;
-    background: #fff;
+    background: $background-white;
+
+    &__bold {
+      font-weight: 400;
+    }
 
     &__items {
       margin: 0;
@@ -311,7 +293,6 @@
       }
 
       &__message-user {
-        float: left;
         position: relative;
         top: -20px;
         display: inline-block;
@@ -407,7 +388,7 @@
     min-height: 104px;
     padding: 10px;
     border: 1px solid #ccc;
-    background: #fff;
+    background: $background-white;
     font-size: 16px;
     line-height: 1.5;
     border-radius: 0;
@@ -424,7 +405,6 @@
     color: #fff;
     display: block;
     line-height: 48px;
-    transition: all ease-out .3s;
     cursor: pointer;
 
     & span {
@@ -434,15 +414,9 @@
   }
 }
 
-.nav-item-link-prev-next {
+.nav-item-link {
   margin: 24px auto 0;
   width: 700px;
-
-  &clearfix:after {
-    content: '';
-    display: block;
-    clear: both;
-  }
 
   & .nav-item-link-prev {
     width: 45%;
@@ -452,7 +426,7 @@
     padding: 0 0 0 14px;
     
     & a {
-      color: #0099e8;
+      color: $link-color;
       font-size: 13px;
     }
   }
@@ -466,7 +440,7 @@
     text-align: right;
 
     & a {
-      color: #0099e8;
+      color: $link-color;
       font-size: 13px;
     }
   }
@@ -476,7 +450,7 @@
   margin: 24px auto;
   padding: 32px 0 24px;
   width: 700px;
-  background: #fff;
+  background: $background-white;
 
   &__text-center {
     text-align: center;
@@ -510,6 +484,7 @@
 .items-in-user-profile {
   width: 700px;
   margin: 0 auto;
+  margin-bottom: 40px;
 
   &__items-box-head {
     font-size: 22px;
@@ -517,8 +492,7 @@
     line-height: 1.4;
 
     & a {
-      color: #0099e8;
-      text-decoration: none;
+      color: $link-color;
     }
   }
 
@@ -526,18 +500,12 @@
     width: auto;
     margin: 0 auto;
 
-    &.clearfix:after {
-      content: '';
-      display: block;
-      clear: both;
-    }
-
     &__item-box {
       width: 220px;
       margin: 0 20px 20px 0;
       position: relative;
       float: left;
-      background: #fff;
+      background: $background-white;
 
       &:nth-child(3n) {
         margin-right: 0;
@@ -566,7 +534,6 @@
           z-index: 1;
           width: 100%;
           opacity: 1;
-          transition: opacity .3s;
           vertical-align: middle;
         }
       }
@@ -587,6 +554,17 @@
       white-space: normal;
       font-size: 16px;
       color: #333;
+
+      &:after {
+        display: block;
+        content: '';
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        width: 50%;
+        height: 1.5em;
+        background: linear-gradient(to right, rgba(255,255,255,0), #fff 72%);
+      }
     }
 
     &__num {
@@ -611,35 +589,25 @@
   }
 }
 
-.items-in-user-profile .related-item-column:last-of-type {
-  margin-bottom: 40px;
-}
-
 .items-box-head {
   font-size: 22px;
   margin: 24px 0 8px;
   line-height: 1.4;
 
   & a {
-    color: #0099e8;
+    color: $link-color;
   }
 
   &-content {
     width: auto;
     margin: 0 auto;
 
-    &.clearfix:after  {
-      content: '';
-      display: block;
-      clear: both;
-    }
-
     &__item-box {
       width: 220px;
       margin: 0 20px 20px 0;
       position: relative;
       float: left;
-      background: #fff;
+      background: $background-white;
 
       &:nth-child(3n) {
         margin-right: 0;
@@ -724,7 +692,6 @@
     font-size: 0;
 
     & li {
-      text-overflow: ellipsis;
       white-space: nowrap;
       display: inline-block;
       font-size: 14px;
@@ -742,23 +709,9 @@
 
       &:last-child {
         font-weight: 600;
-
       }
     }
   }
-}
-
-
-.owl-carousel .owl-nav {
-  display: none;
-}
- 
-.owl-nav.disabled .owl-prev, .owl-nav.disabled .owl-next {
-  display: none;
-}
-
-.owl-nav.disabled .owl-prev, .owl-nav.disabled .owl-next {
-  display: none;
 }
 
 .icon-good {
@@ -774,11 +727,11 @@ color: #ef5185;
 }
 
 .icon-like {
-  color: #ea352d;
+  color: $like-icon;
 }
 
 .icon-lock {
-  color: #0099e8;
+  color: $link-color;
 }
 
 .bold {
@@ -795,7 +748,7 @@ color: #ef5185;
   position: absolute;
   top: 50%;
   transform: translate(0, -50%);
-  color: #0099e8;
+  color: $link-color;
 }
 
 .icon-facebook {
@@ -840,14 +793,13 @@ color: #ef5185;
   }
 }
 
-
 figure {
   margin: 0;
   padding: 0;
 }
 
-
-
-
-
-
+.clearfix:after {
+  content: '';
+  display: block;
+  clear: both;
+}

--- a/app/assets/stylesheets/item_sells.scss
+++ b/app/assets/stylesheets/item_sells.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the item_sells controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/tops/_footer.scss
+++ b/app/assets/stylesheets/tops/_footer.scss
@@ -60,7 +60,7 @@
 
 .footer {
   background-color: rgb(34, 34, 34);
-  color: $white;
+  color: white;
   font-size: 12px;
   padding: 0px 20px 10px;
   display: block;
@@ -89,7 +89,7 @@
         margin: 16px 0px 0px;
 
         &__link {
-          color: $white;
+          color: white;
           opacity: 0.7;
           word-break : break-all;
         }
@@ -133,7 +133,7 @@
   max-height: 100%;
   width: 30px;
   margin-right: 20px;
-  color: $white;
+  color: white;
   font-size: 25px;
 }
 

--- a/app/assets/stylesheets/tops/_header.scss
+++ b/app/assets/stylesheets/tops/_header.scss
@@ -1,6 +1,6 @@
 .header {
   width: 100%;
-  background-color: $white;
+  background-color: $background-white;
   position: relative;
   box-shadow: $box-shadow-black 0px 2px 4px;
   z-index: 2;
@@ -30,7 +30,7 @@
       }
 
       &__search-input {
-        background-color: $whitesmoke;
+        background-color: whitesmoke;
         font-size: 16px;
         height: 40px;
         line-height: 1.4em;

--- a/app/assets/stylesheets/tops/_main-content.scss
+++ b/app/assets/stylesheets/tops/_main-content.scss
@@ -124,7 +124,7 @@
 
 .popular-categories {
   padding: 56px 0 30px;
-  background-color: $white;
+  background-color: $background-white;
   position: relative;
   top: 0;
   left: 50%;
@@ -219,7 +219,7 @@
       align-items: center;
       display: flex;
       position: relative;
-      background-color: $white;
+      background-color: $background-white;
       box-shadow: 0 2px 4px $box-shadow-black;
       flex-direction: column-reverse;
       margin: 0;
@@ -282,7 +282,7 @@
 
   &__text {
     font-size: 22px;
-    color: $white;
+    color: white;
   }
 }
 
@@ -290,7 +290,7 @@
   margin-top: 8px;
   max-width: 100%;
   max-height: 100%;
-  color: $white;
+  color: white;
   display: block;
   overflow: hidden;
   font-size: 60px;
@@ -301,7 +301,7 @@
   background: rgba(0,0,0,.4);
   border-radius: 0 14px 14px 0;
   box-sizing: border-box;
-  color: $white;
+  color: white;
   display: inline-flex;
   font-size: 17px;
   height: 28px;
@@ -327,7 +327,7 @@
 .more-item {
   font-size: 14px;
   align-items: center;
-  color: #0095ee;
+  color: $link-color;
   cursor: pointer;
   display: inline-flex;
   line-height: 1.4em;

--- a/app/controllers/item_informations_controller.rb
+++ b/app/controllers/item_informations_controller.rb
@@ -1,0 +1,6 @@
+class ItemInformationsController < ApplicationController
+
+  def index
+  end
+  
+end

--- a/app/helpers/item_informations_helper.rb
+++ b/app/helpers/item_informations_helper.rb
@@ -1,0 +1,2 @@
+module ItemInformationsHelper
+end

--- a/app/views/item_informations/_main-content.html.haml
+++ b/app/views/item_informations/_main-content.html.haml
@@ -1,0 +1,347 @@
+%section.item-box-container
+  %h1.item-name 希少な超望遠レンズキット 大人気機種 LUMIX GF7
+  .item-main-content.clearfix
+    .item-photo
+      .item-photo__list
+        .item-photo__list__outer
+          .item-photo__list__outer-stage
+            .item-photo__list__outer-stage__item
+              .item-photo__list__outer-stage__item-inner
+                = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_1.jpg?1580358437', class: 'item-photo__list__outer-stage__item-inner__lazy', alt: "希少な超望遠レンズキット 大人気機種 LUMIX GF7"
+            .item-photo__list__outer-stage__item
+              .item-photo__list__outer-stage__item-inner
+                = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_2.jpg?1580358437', class: 'item-photo__list__outer-stage__item-inner__lazy', alt: "希少な超望遠レンズキット 大人気機種 LUMIX GF7"
+            .item-photo__list__outer-stage__item
+              .item-photo__list__outer-stage__item-inner
+                = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_3.jpg?1580358437', class: 'item-photo__list__outer-stage__item-inner__lazy', alt: "希少な超望遠レンズキット 大人気機種 LUMIX GF7"
+            .item-photo__list__outer-stage__item
+              .item-photo__list__outer-stage__item-inner
+                = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_4.jpg?1580358437', class: 'item-photo__list__outer-stage__item-inner__lazy', alt: "希少な超望遠レンズキット 大人気機種 LUMIX GF7"
+        .owl-nav.disabled
+          .owl-prev prev
+          .owl-next next
+        .item-photo__list__outer__dots
+          .item-photo__list__outer__dots__dot.active
+            %span
+            .item-photo__list__outer__dots__dot__inner
+              = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_1.jpg?1580358437'
+          .item-photo__list__outer__dots__dot
+            %span
+            .item-photo__list__outer__dots__dot__inner
+              = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_2.jpg?1580358437'
+          .item-photo__list__outer__dots__dot
+            %span
+            .item-photo__list__outer__dots__dot__inner
+              = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_3.jpg?1580358437'
+          .item-photo__list__outer__dots__dot
+            %span
+            .item-photo__list__outer__dots__dot__inner
+              = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_4.jpg?1580358437'
+
+    %table.item-detail-table
+      %tbody
+        %tr
+          %th 出品者
+          %td
+            = link_to "hoge", "#"
+            %div
+              .item-user-ratings
+                = icon('fas', 'grin', class: 'icon-good')
+                %span 2063
+              .item-user-ratings
+                = icon('fas', 'meh', class: 'icon-normal')
+                %span 10
+              .item-user-ratings
+                = icon('fas', 'tired', class: 'icon-bad')
+                %span 1
+        %tr
+          %th カテゴリー
+          %td
+            = link_to "#" do
+              %div 家電・スマホ・カメラ
+            = link_to "#" do
+              .item-detail-table-sub-category
+                = icon('fas', 'angle-right', class: 'icon-arrow-right')
+                カメラ
+            = link_to "#" do
+              .item-detail-table-sub-category
+                = icon('fas', 'angle-right', class: 'icon-arrow-right')
+                デジタルカメラ
+        %tr
+          %th ブランド
+          %td
+            = link_to "#" do
+              %div
+                パナソニック
+        %tr
+          %th 商品の状態
+          %td 目立った傷や汚れなし
+        %tr
+          %th 配送料の負担
+          %td 送料込み
+        %tr
+          %th 配送の方法
+          %td 未定
+        %tr
+          %th 配送元地域
+          %td
+            = link_to "三重県", "#"
+        %tr
+          %th 発送日の目安
+          %td 2~3日で発送
+  .item-price-box
+    %span.item-price-box__bold ¥35,800
+    %span.item-price-box__tax (税込)
+    %span.item-price-box__fee 送料込み
+  .text-center
+    .text-center__sales-point-message
+      売上金¥3,000をお持ちです
+  = link_to "#", class: "item-buy-btn" do
+    購入画面に進む
+  .item-description
+    %p.item-description__inner
+      ご覧いただきありがとうございます
+      即購入いただいて大丈夫です！
+      ✨超お買い得！！予備バッテリー&amp;SDカード&amp;新品カメラポーチ付き✨
+      
+      ✨✨こんなセットが欲しかった✨✨⭐️⭐️自撮り＋Wi-Fi機能付き♪⭐️⭐️
+      
+      ルミックス GF7と OLYMPUS M.Zuiko 40-150mmの超望遠レンズセット
+      
+      【今回オススメしたい５つの理由！】
+      
+      ★オシャレでファッションにも良く合うブラウン♪
+      ★WiFi機能搭載で写真のシェアが簡単♪
+      ★嬉しい全国送料無料♪
+      ★SDカード付きなので届いてすぐに使える♪
+      ★到着日から７日間の初期不良付きで安心♪
+      
+      【商品説明】
+      
+      ■WiFi搭載なので、スマホやタブレットに写真を簡単転送♪
+      ■モニターが回転するので、自撮りも楽々♪美白効果も設定できる♪
+      ■セピアやトイカメラなど19種類の補正ができるから写真を撮るのが楽しくなる♪
+      ■料理を美味しそうに撮影できる機能も搭載♪
+
+  .item-button-container.clearfix
+    .item-button-container__left
+      = button_tag '#', class: 'item-button-container__left__like', name: "unlike", type: "button" do
+        = icon('fas', 'heart', class: 'rubber-band')
+        %span いいね!
+        %span.fade-in-up 9
+      = link_to "#", class: 'item-button-container__left__report' do
+        = icon('far', 'flag', class: 'icon-flag')
+        %span 不適切な商品の報告
+    .item-button-container__right
+      = link_to "#", class: 'item-button-container__right__relief' do
+        = icon('fas', 'lock', class: 'icon-lock')
+        %span あんしん・あんぜんへの取り組み
+.item-detail-message
+  .item-detail-message__container
+    .item-detail-message__container__content
+      %ul.item-detail-message__container__content__items
+        %li.clearfix
+          .item-detail-message__container__content__items__message-user
+            %figure
+              .item-detail-message__container__content__items__message-user__unknown
+                = image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/user-icon.svg?73731125', alt: "none"
+              %figcaption.bold
+          .item-detail-message__container__content__items__message-body
+            .item-detail-message__container__content__items__message-body__text 出品者がコメントを削除しました
+            .item-detail-message__container__content__items__message-icons.clearfix
+              %time.item-detail-message__container__content__items__message-icons__icon-left
+                = icon('far', 'clock', class: 'icon-time')
+                %span 7 日前
+            %i.icon-balloon
+    .item-detail-message__container__content
+      %form.message-form{action: "#", method: "POST"}
+        %input{name: "", type: "hidden", value: ""}
+        %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        %input{name: "", type: "hidden", value: ""}
+        %input{name: "", type: "hidden", value: ""}
+        %textarea.message-form__textarea-default{name: "", type: "text", value: ""}
+        = button_tag '#', class: 'message-form__submit', name: "submit", type: "button" do
+          %span コメントする
+%ul.nav-item-link-prev-next.clearfix
+  %li.nav-item-link-prev
+    = link_to "#" do
+      = icon('fas', 'angle-left', class: 'icon-arrow-left')
+      120cm ● petit main ケーブルニットセットアップ ● アイボリー
+  %li.nav-item-link-next
+    = link_to "#" do
+      < 値下げしました！>サッシュベルト(ブラック)
+      = icon('fas', 'angle-right', class: 'icon-arrow-right')
+.item-social-media-box
+  .item-social-media-box__text-center
+  %ul.item-social-media-box__text-center__social-media-box
+    %li
+      = link_to "#", class: "share-btn" do
+        = icon('fab', 'facebook-square', class: 'icon-facebook')
+    %li
+      = link_to "#", class: "share-btn" do
+        = icon('fab', 'twitter-square', class: 'icon-twitter')
+    %li
+      = link_to "#", class: "share-btn" do
+        = icon('fab', 'pinterest-square', class: 'icon-pinterest')
+.items-in-user-profile
+  %section.items-box-container.clearfix.related-item-column.items-in-user-profile
+    %h2.items-in-user-profile__items-box-head
+      = link_to "hogeさんのその他の出品", "#"
+    .items-in-user-profile__items-box-content.clearfix
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m61442850335_1.jpg?1581247501', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "希少な超望遠レンズセット❤️パナソニック LUMIX GF6"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              希少な超望遠レンズセット パナソニック LUMIX GF6
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥28,000
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 14
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m45698129728_1.jpg?1571824556', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "⭐️予備バッテリー付き⭐️最上級 プレミアム オリンパスOM-D E-M10"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              ⭐️予備バッテリー付き⭐️最上級 プレミアム オリンパスOM-D E-M10 
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥38,000
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 8
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m33776418270_1.jpg?1573445745', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "コスパ最強手ぶれ補正内蔵望遠レンズ付き ニコン D7000"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              コスパ最強手ぶれ補正内蔵望遠レンズ付き ニコン D7000
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥34,000
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 3
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m73573865074_1.jpg?1577443076', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "新品のWi-Fi SD&予備バッテリー付き Canon Kiss X7"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              新品のWi-Fi SD&amp;予備バッテリー付き Canon Kiss X7
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥35,800
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 9
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m30192132145_1.jpg?1577357163', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "✨便利✨Nikon バッテリーグリップ MB-D11 ニコン純正品"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              ✨便利✨Nikon バッテリーグリップ MB-D11 ニコン純正品
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥8,500
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 14
+      %section.items-in-user-profile__items-box-content__item-box
+        = link_to "#" do
+          %figure.items-in-user-profile__items-box-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m59775588595_1.jpg?1577608247', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "新品のWi-Fi SD&自撮り&動画対応 キャノン Kiss X5"
+          .items-in-user-profile__items-box-content__body
+            %h3.items-in-user-profile__items-box-content__name
+              新品のWi-Fi SD&amp;自撮り&amp;動画対応 キャノン Kiss X5
+            .items-in-user-profile__items-box-content__num
+              .items-in-user-profile__items-box-content__num__price ¥27,800
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+  %section.items-box-container.clearfix.related-item-column
+    %h2.items-box-head
+      = link_to "#" do
+        パナソニックのデジタルカメラ その他の商品
+    .items-box-head-content.clearfix
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m52108250127_1.jpg?1581215629', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "パナソニック デジカメ ピンク"
+          .items-box-body
+            %h3.items-box-body__name
+              パナソニック デジカメ ピンク
+            .items-box-body__num
+              .items-box-body__num__price ¥4,499
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m40472079846_1.jpg?1576295495', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "圧倒的人気&可愛さの頂点へ ルミックスDMC-GF7"
+          .items-box-body
+            %h3.items-box-body__name
+              圧倒的人気&amp;可愛さの頂点へ ルミックスDMC-GF7
+            .items-box-body__num
+              .items-box-body__num__price ¥36,800
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m88493542226_1.jpg?1581203135', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "★超美品★自撮り★スマホ転送★タッチパネル★付属品多数パナソニックG2★"
+          .items-box-body
+            %h3.items-box-body__name
+              超美品★自撮り★スマホ転送★タッチパネル★付属品多数パナソニックG2
+            .items-box-body__num
+              .items-box-body__num__price ¥23,800
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m55305551667_1.jpg?1578360077', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "自撮り＆Wi-Fi&パンケーキレンズ ルミックス GF6"
+          .items-box-body
+            %h3.items-box-body__name
+              自撮り＆Wi-Fi&amp;パンケーキレンズ ルミックス GF6
+            .items-box-body__num
+              .items-box-body__num__price ¥29,800
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m90773807594_1.jpg?1568207827', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "デジタルカメラ LUMIX デジカメ FX60"
+          .items-box-body
+            %h3.items-box-body__name
+              デジタルカメラ LUMIX デジカメ FX60
+            .items-box-body__num
+              .items-box-body__num__price ¥2,980
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+      %section.items-box-head-content__item-box
+        = link_to "#" do
+          %figure.items-box-head-content__item-box__photo
+            = image_tag 'https://static.mercdn.net/thumb/photos/m45308657792_1.jpg?1580370038', class: 'items-in-user-profile__items-box-content__item-box__photo__lazyloaded', alt: "高画質コンパクト☆LUMIX DMC-GF2☆スマホに転送お散歩カメラ☆"
+          .items-box-body
+            %h3.items-box-body__name
+              高画質コンパクト☆LUMIX DMC-GF2☆スマホに転送お散歩カメラ☆
+            .items-box-body__num
+              .items-box-body__num__price ¥16,980
+              .items-in-user-profile__items-box-content__num__like
+                = icon('far', 'heart', class: 'icon-like-border')
+                %span 16
+%nav.pos-bottom
+  %ul
+    %li
+      = link_to "#" do
+        %span メルカリ
+      = icon('fas', 'angle-right', class: 'icon-arrow-right')
+    %li
+      %span 希少な超望遠レンズ&amp;予備バッテリー大人気機種 LUMIX GF7

--- a/app/views/item_informations/_main-content.html.haml
+++ b/app/views/item_informations/_main-content.html.haml
@@ -1,5 +1,5 @@
 %section.item-box-container
-  %h1.item-name 希少な超望遠レンズキット 大人気機種 LUMIX GF7
+  %h1.item-box-container__item-name 希少な超望遠レンズキット 大人気機種 LUMIX GF7
   .item-main-content.clearfix
     .item-photo
       .item-photo__list
@@ -17,24 +17,17 @@
             .item-photo__list__outer-stage__item
               .item-photo__list__outer-stage__item-inner
                 = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_4.jpg?1580358437', class: 'item-photo__list__outer-stage__item-inner__lazy', alt: "希少な超望遠レンズキット 大人気機種 LUMIX GF7"
-        .owl-nav.disabled
-          .owl-prev prev
-          .owl-next next
         .item-photo__list__outer__dots
           .item-photo__list__outer__dots__dot.active
-            %span
             .item-photo__list__outer__dots__dot__inner
               = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_1.jpg?1580358437'
           .item-photo__list__outer__dots__dot
-            %span
             .item-photo__list__outer__dots__dot__inner
               = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_2.jpg?1580358437'
           .item-photo__list__outer__dots__dot
-            %span
             .item-photo__list__outer__dots__dot__inner
               = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_3.jpg?1580358437'
           .item-photo__list__outer__dots__dot
-            %span
             .item-photo__list__outer__dots__dot__inner
               = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_4.jpg?1580358437'
 
@@ -128,7 +121,7 @@
       = button_tag '#', class: 'item-button-container__left__like', name: "unlike", type: "button" do
         = icon('fas', 'heart', class: 'rubber-band')
         %span いいね!
-        %span.fade-in-up 9
+        %span 9
       = link_to "#", class: 'item-button-container__left__report' do
         = icon('far', 'flag', class: 'icon-flag')
         %span 不適切な商品の報告
@@ -145,9 +138,22 @@
             %figure
               .item-detail-message__container__content__items__message-user__unknown
                 = image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/user-icon.svg?73731125', alt: "none"
-              %figcaption.bold
+              %figcaption.item-detail-message__container__content__bold hoge
           .item-detail-message__container__content__items__message-body
             .item-detail-message__container__content__items__message-body__text 出品者がコメントを削除しました
+            .item-detail-message__container__content__items__message-icons.clearfix
+              %time.item-detail-message__container__content__items__message-icons__icon-left
+                = icon('far', 'clock', class: 'icon-time')
+                %span 7 日前
+            %i.icon-balloon
+        %li.clearfix
+          .item-detail-message__container__content__items__message-user
+            %figure
+              .item-detail-message__container__content__items__message-user__unknown
+                = image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/user-icon.svg?73731125', alt: "none"
+              %figcaption.item-detail-message__container__content__bold a
+          .item-detail-message__container__content__items__message-body
+            .item-detail-message__container__content__items__message-body__text 33,000円でも可能なら即買いしますが可能でしょうか？
             .item-detail-message__container__content__items__message-icons.clearfix
               %time.item-detail-message__container__content__items__message-icons__icon-left
                 = icon('far', 'clock', class: 'icon-time')
@@ -162,7 +168,7 @@
         %textarea.message-form__textarea-default{name: "", type: "text", value: ""}
         = button_tag '#', class: 'message-form__submit', name: "submit", type: "button" do
           %span コメントする
-%ul.nav-item-link-prev-next.clearfix
+%ul.nav-item-link.clearfix
   %li.nav-item-link-prev
     = link_to "#" do
       = icon('fas', 'angle-left', class: 'icon-arrow-left')
@@ -184,7 +190,7 @@
       = link_to "#", class: "share-btn" do
         = icon('fab', 'pinterest-square', class: 'icon-pinterest')
 .items-in-user-profile
-  %section.items-box-container.clearfix.related-item-column.items-in-user-profile
+  %section.items-in-user-profile.clearfix
     %h2.items-in-user-profile__items-box-head
       = link_to "hogeさんのその他の出品", "#"
     .items-in-user-profile__items-box-content.clearfix

--- a/app/views/item_informations/index.html.haml
+++ b/app/views/item_informations/index.html.haml
@@ -1,4 +1,4 @@
 .wrapper
   =render 'tops/shared/header'
-  =render 'main'
+  =render 'main-content'
   =render 'tops/shared/footer'

--- a/app/views/item_informations/index.html.haml
+++ b/app/views/item_informations/index.html.haml
@@ -1,0 +1,4 @@
+.wrapper
+  =render 'tops/shared/header'
+  =render 'main'
+  =render 'tops/shared/footer'

--- a/app/views/tops/_main-content.html.haml
+++ b/app/views/tops/_main-content.html.haml
@@ -44,13 +44,13 @@
             = icon('fas', 'angle-right', class: 'style-right')
         %ul.category-groups
           %li.category-groups__content
-            = link_to "#", class: "category-groups__content__link" do
+            = link_to item_informations_path, class: "category-groups__content__link" do
               %figure.category-groups__content__items
                 %figcaption.category-groups__content__items__item
-                  %span.category-groups__content__items__item__title 新品　レスポートサック　ポーチ　コスメティッククラッチ　シルバー
+                  %span.category-groups__content__items__item__title 希少な超望遠レンズキット 大人気機種 LUMIX GF7
                 .category-groups__content__items__item__description
-                  %span{class: 'item-price'} ¥2,099
-                  = image_tag 'https://static.mercdn.net/thumb/photos/m91517264666_1.jpg?1580275903', class: 'show-image', alt: "画像が表示できません"
+                  %span{class: 'item-price'} ¥35,800
+                  = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m63148262496_1.jpg?1580358437', class: 'show-image', alt: "画像が表示できません"
           %li.category-groups__content
             = link_to "#", class: "category-groups__content__link" do
               %figure.category-groups__content__items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
 
   resources :tops, only: [:index]
   resources :items_sell, only: [:index]
+  resources :item_informations, only: [:index]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/item_informations_controller_test.rb
+++ b/test/controllers/item_informations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemInformationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
商品詳細ページのマークアップ を実施した。

## 実装内容
### １．item_informationsコントローラー作成
### ２．ルーティング追加
### ３．ビューファイル作成
・views/item_informations以下に[index.html.haml]と[_main-content.html.haml]を作成。
・ヘッダー・フッターはトップページのビューをrenderして使用。
### ４．メイン実装
#### ①商品画像の切り替えについて
・商品画像にカーソルを当てて表示画像を切り替える機能は別のブランチで実装する。
#### ②売り切れ時のビューファイルについて
・売り切れ時に購入ボタンとコメントボタンの表示を切り替えて購入およびコメントできなく
する機能は別のブランチで実装する。
#### ③いいね！ボタンについて
・いいね！ボタンを押していない場合の変化については別のブランチで実装する。

### ５．その他
#### ①mixinファイルについて
・clearfixはmain-content.scssの最後に一括して記述をすれば何度も呼び出す必要がなくなるため、mixinファイルは作成しない。(今後のマークアップで必要になった場合に作成する。)
#### ②color.scssについて
・$white→ $background-white
・$whitesmoke→$border-line
　へ変更。トップページのscssファイルも合わせて修正した。

# Why
商品の購入にあたり、詳細情報の確認は必要であるため。

## 実装内容
### ４．メイン実装
・マークアップ のブランチであるため、見た目のみを実装。データベースの状態やユーザーのアクションに対してビューを変化させる内容は、サーバーサイド実装時に合わせて実装する。

#### ②color.scssについて
・どのページもwrapperで[whitesmoke],コンテンツ部分で[white]の背景色を当てているページが
多いため、変更。背景色以外でも同じ色を設定している箇所は多くあるが規則性がないため、color.scssには変数として記述しない。

<img width="1440" alt="スクリーンショット 2020-02-12 15 17 22" src="https://user-images.githubusercontent.com/57065520/74308222-fcd7c680-4daa-11ea-9363-acaf57d756e1.png">

<img width="1440" alt="スクリーンショット 2020-02-12 15 17 33" src="https://user-images.githubusercontent.com/57065520/74308243-0e20d300-4dab-11ea-8298-065e2d0882a2.png">

<img width="1440" alt="スクリーンショット 2020-02-12 15 17 46" src="https://user-images.githubusercontent.com/57065520/74308265-18db6800-4dab-11ea-94e9-dd1da078dc72.png">

<img width="1440" alt="スクリーンショット 2020-02-12 15 18 02" src="https://user-images.githubusercontent.com/57065520/74308285-2264d000-4dab-11ea-9dfd-2330850ce074.png">

<img width="1440" alt="スクリーンショット 2020-02-12 15 18 13" src="https://user-images.githubusercontent.com/57065520/74308302-2bee3800-4dab-11ea-957e-17e6cda40aa4.png">

<img width="1440" alt="スクリーンショット 2020-02-12 15 18 22" src="https://user-images.githubusercontent.com/57065520/74308315-37d9fa00-4dab-11ea-8a0c-4312c70fb43f.png">

