### PR TITLE
ユーザー本人確認ページマークアップ 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,4 @@
 @import "mypages/index.scss";
 @import "mypages/shared/header";
 @import "mypages/shared/side";
+@import "mypages/identification.scss";

--- a/app/assets/stylesheets/mypages/identification.scss
+++ b/app/assets/stylesheets/mypages/identification.scss
@@ -50,13 +50,7 @@
       & .input-default {
         width: 100%;
         margin-top: 8px;
-        height: 48px;
         padding: 10px 16px 8px;
-        border-radius: 4px;
-        border: 1px solid #ccc;
-        background: #fff;
-        line-height: 1.5;
-        font-size: 16px;
         text-align: left;
       }
 

--- a/app/assets/stylesheets/mypages/identification.scss
+++ b/app/assets/stylesheets/mypages/identification.scss
@@ -21,21 +21,16 @@
     border-bottom: 1px solid #f5f5f5;
 
     & p {
-      margin: 8px 0 0;
+      margin-top: 8px;
       line-height: 1.5;
     }
 
     & .text-right {
       text-align: right;
-
-      & a {
-        color: #0099e8;
-        text-decoration: none;
-      }
     }
 
     & .form-group {
-      margin: 40px 0 0;
+      margin-top: 40px;
 
       & label {
         font-weight: 600;
@@ -44,7 +39,7 @@
 
       & .form-arbitrary {
         background: #ccc;
-        margin: 0 0 0 8px;
+        margin-bottom: 8px;
         padding: 2px 4px;
         border-radius: 2px;
         color: #fff;
@@ -54,7 +49,7 @@
 
       & .input-default {
         width: 100%;
-        margin: 8px 0 0;
+        margin-top: 8px;
         height: 48px;
         padding: 10px 16px 8px;
         border-radius: 4px;
@@ -66,7 +61,7 @@
       }
 
       & .select-wrap {
-        margin: 8px 0 0;
+        margin-top: 8px;
         position: relative;
         background: #fff;
 
@@ -100,7 +95,7 @@
     }
 
     & .btn-red {
-      margin: 40px 0 0 0;
+      margin-top: 40px;
       background: #ea352d;
       border: 1px solid #ea352d;
       color: #fff;
@@ -109,8 +104,6 @@
       line-height: 48px;
       font-size: 14px;
       border: 1px solid transparent;
-      -webkit-transition: all ease-out .3s;
-      transition: all ease-out .3s;
       cursor: pointer;
       text-align: center;
     }

--- a/app/assets/stylesheets/mypages/identification.scss
+++ b/app/assets/stylesheets/mypages/identification.scss
@@ -1,0 +1,118 @@
+.mypage-identification {
+  margin-top: 40px;
+  background: #fff;
+  font-size: 14px;
+
+  &:first-child {
+    margin: 0;
+  }
+
+  &__head {
+    font-size: 24px;
+    padding: 8px 24px;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    line-height: 1.4;
+    font-weight: bold;
+  }
+
+  &__right-single-inner {
+    padding: 64px;
+    border-bottom: 1px solid #f5f5f5;
+
+    & p {
+      margin: 8px 0 0;
+      line-height: 1.5;
+    }
+
+    & .text-right {
+      text-align: right;
+
+      & a {
+        color: #0099e8;
+        text-decoration: none;
+      }
+    }
+
+    & .form-group {
+      margin: 40px 0 0;
+
+      & label {
+        font-weight: 600;
+        display: inline-block;
+      }
+
+      & .form-arbitrary {
+        background: #ccc;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        vertical-align: top;
+      }
+
+      & .input-default {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+        text-align: left;
+      }
+
+      & .select-wrap {
+        margin: 8px 0 0;
+        position: relative;
+        background: #fff;
+
+        & .icon-arrow-bottom{
+          position: absolute;
+          right: 16px;
+          top: 50%;
+          z-index: 2;
+          color: #888;
+          font-size: 8px;
+          -webkit-transform: translate(0, -50%);
+          transform: translate(0, -50%);
+        }
+
+        & .select-default {
+          width: 100%;
+          position: relative;
+          z-index: 2;
+          height: 48px;
+          padding: 0 16px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          background: 0;
+          font-size: 16px;
+          line-height: 1.5;
+          cursor: pointer;
+          outline: 0;
+          -webkit-appearance: none;
+        }
+      }
+    }
+
+    & .btn-red {
+      margin: 40px 0 0 0;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      border: 1px solid transparent;
+      -webkit-transition: all ease-out .3s;
+      transition: all ease-out .3s;
+      cursor: pointer;
+      text-align: center;
+    }
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -4,6 +4,7 @@ class MypagesController < ApplicationController
   end
 
   def identification
+    @address = Prefecture.all
   end
 
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -3,4 +3,7 @@ class MypagesController < ApplicationController
   def index
   end
 
+  def identification
+  end
+
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,5 +1,6 @@
 class Prefecture < ActiveHash::Base
   self.data = [
+      {id: 0, name: '---'},
       {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
       {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
       {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,6 +1,6 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-      {id: 0, name: '---'},
+    
       {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
       {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
       {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,0 +1,75 @@
+.wrapper
+  .mypage-header
+    = render 'tops/shared/header'
+  %nav.bread-crumbs
+    %ul
+      %li
+        = link_to root_path do
+          %span フリマアプリ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to mypages_path do
+          %span マイページ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        %span 本人情報の登録
+  %main.mypage-container.clearfix
+    .mypage-container__right-content
+      %section.mypage-identification
+        %h2.mypage-identification__head 本人情報の登録
+        %form.mypage-identification__right-single-inner{action: "#", method: "POST", novalidate: ""}
+          %div
+            %p
+              お客さまの本人情報をご登録ください。
+              %br
+              登録されたお名前・生年月日を変更する場合は、本人確認書類の提出が必要になります。
+            %p.text-right
+              = link_to "#" do
+                本人確認書類のアップロードについて
+                = icon('fas', 'angle-right', class: 'mypage-style-right')
+          .form-group
+            %label お名前
+            %p hoge
+          .form-group
+            %label お名前カナ
+            %p hoge
+          .form-group
+            %label{for: "birthday"} 生年月日
+            %p 2000/01/01
+          .form-group
+            %label{for: "zip_code"} 郵便番号
+            %span.form-arbitrary 任意
+            %input.input-default{name: "zip_code", placeholder: "例）1234567", type: "text", value: ""}
+          .form-group
+            %label{for: "zip_code"} 都道府県
+            %span.form-arbitrary 任意
+            .select-wrap
+              = icon('fas', 'chevron-down', class: 'icon-arrow-bottom')
+              %select.select-default{name: "prefecture"}
+                - @address.each do |address|
+                  %option{value: "", prompt: "--"}
+                    = address.name
+          .form-group
+            %label{for: "city"} 市区町村
+            %span.form-arbitrary 任意
+            %input.input-default{name: "city", placeholder: "例) 横浜市緑区", type: "text", value: ""}
+          .form-group
+            %label{for: "address2_label"} 建物名
+            %span.form-arbitrary 任意
+            %input.input-default{name: "address2", placeholder: "例) 柳ビル103", type: "text", value: ""}
+          %button.btn-red{type: "submit"} 登録する
+          .form-group.text-right
+            %p
+              = link_to "#" do
+                本人情報の登録について
+                = icon('fas', 'angle-right', class: 'mypage-style-right')
+          %input{name: "__csrf_value", type: "hidden", value: ""}
+    = render 'mypages/shared/side'
+    .sell-icon
+      %a.sell-icon__link{href: "#"}
+        .sell-icon__content
+          .sell-icon__text 出品
+          = icon('fas', 'camera', class: 'camera-icon')
+  =render 'tops/shared/footer'
+
+

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -65,11 +65,7 @@
                 = icon('fas', 'angle-right', class: 'mypage-style-right')
           %input{name: "__csrf_value", type: "hidden", value: ""}
     = render 'mypages/shared/side'
-    .sell-icon
-      %a.sell-icon__link{href: "#"}
-        .sell-icon__content
-          .sell-icon__text 出品
-          = icon('fas', 'camera', class: 'camera-icon')
+    = render 'tops/shared/sell-icon'
   =render 'tops/shared/footer'
 
 

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -46,8 +46,9 @@
             .select-wrap
               = icon('fas', 'chevron-down', class: 'icon-arrow-bottom')
               %select.select-default{name: "prefecture"}
+                %option --
                 - @address.each do |address|
-                  %option{value: "", prompt: "--"}
+                  %option{value: ""}
                     = address.name
           .form-group
             %label{for: "city"} 市区町村

--- a/app/views/mypages/shared/_side.html.haml
+++ b/app/views/mypages/shared/_side.html.haml
@@ -86,7 +86,7 @@
           メール/パスワード
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
-        = link_to "#", class: 'mypage-nav__list__item' do
+        = link_to identification_mypages_path, class: 'mypage-nav__list__item' do
           本人情報
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,8 @@ Rails.application.routes.draw do
     end
   end
   resources :mypages, only: [:index] do
+    collection do
+      get 'identification'
+    end
   end
 end


### PR DESCRIPTION
# What
ユーザー本人確認ページのマークアップを実施した。

## 実装内容
### １．ルーティング設定
### ２．アクション追加
・mypages_controllerに[identification]アクションを定義。
### ３．メイン実装
#### ①ヘッダーについて
・トップページのヘッダーをrenderさせて表示。
#### ②メインについて
・都道府県のプルダウンはactive_hashを用いて実装。
　id０に「---」を追加。
#### ③左のサイドバーについて
・マイページのサイドバーをrenderさせて表示。
#### ④フッターについて
・トップページのフッターをrenderさせて表示。

# Why
新規登録時に登録したユーザー情報を更新できるようにするため。

<img width="1427" alt="スクリーンショット 2020-02-21 12 27 58" src="https://user-images.githubusercontent.com/57065520/75001778-b0287580-54a5-11ea-846c-ff3083226b76.png">

<img width="1427" alt="スクリーンショット 2020-02-21 12 28 10" src="https://user-images.githubusercontent.com/57065520/75001790-b9194700-54a5-11ea-8471-462fbcd2454b.png">

<img width="1427" alt="スクリーンショット 2020-02-21 12 28 21" src="https://user-images.githubusercontent.com/57065520/75001804-c33b4580-54a5-11ea-8148-cc5ab47db027.png">

