### PR TITLE
ユーザープロフィール編集画面のマークアップ実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@
 /config/master.key
 public/uploads/*
 .history/
-.DS_Store
+*.DS_Store

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,4 @@
 @import "mypages/index.scss";
 @import "mypages/shared/header";
 @import "mypages/shared/side";
+@import "mypages/profile";

--- a/app/assets/stylesheets/mypages/profile.scss
+++ b/app/assets/stylesheets/mypages/profile.scss
@@ -1,0 +1,73 @@
+.mypage-container {
+
+    &__right-content {
+
+      & .profile-container {
+        background: #fff;
+
+        &__head {
+          font-size: 24px;
+          padding: 8px 24px;
+          border-bottom: 1px solid #f5f5f5;
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.4;
+        }
+
+      & .setting-profile-icon {
+        padding: 72px 16px 24px;
+        background-image: image-url("mypage-user-icon-background-color.jpg");
+        background-repeat: no-repeat;
+        background-size: cover;
+        text-align: center;
+        font-size: 0;
+
+        & figure {
+          display: inline-block;
+          overflow: hidden;
+          border-radius: 50%;
+          vertical-align: middle;
+
+          & .user-icon {
+            width: 60px;
+            height: 60px;
+            background-color: Whitesmoke;
+          }
+        }
+
+        & .input-default {
+          text-align: left;
+          width: 220px;
+          margin: 0 0 0 8px;
+          vertical-align: middle;
+        }
+      }
+
+      & .setting-profile-content {
+        padding: 40px 16px;
+
+        & .textarea-default {
+          min-height: 216px;
+          width: 100%;
+          padding: 10px;
+          border: 1px solid #ccc;
+          line-height: 1.5;
+          display: block;
+        }
+
+        & .btn-default.btn-red {
+          margin: 16px 0 0;
+          background: #ea352d;
+          border: 1px solid #ea352d;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          cursor: pointer;
+          text-align: center;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -3,4 +3,6 @@ class MypagesController < ApplicationController
   def index
   end
 
+  def profile
+  end
 end

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,0 +1,35 @@
+.wrapper
+  .mypage-header
+    = render 'tops/shared/header'
+  %nav.bread-crumbs
+    %ul
+      %li
+        = link_to root_path do
+          %span フリマアプリ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to root_path do
+          %span マイページ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        %span プロフィール
+  %main.mypage-container.clearfix
+    .mypage-container__right-content
+      %section.profile-container
+        %h2.profile-container__head
+          プロフィール
+        %form{action: "https://www.mercari.com/jp/mypage/profile/", method: "POST"}
+          %input{name: "__csrf_value", type: "hidden", value: "fafebec3310eaf0918dacc38d7d7aad1dc7bfa2e232777baaaf32de3672af8cbf9973e68172a3f137ebfd597393041b81a9bcbb66f6ea631c5d475b99e3e8abac"}
+          .setting-profile-icon
+            %figure
+              = image_tag "https://icooon-mono.com/i/icon_00146/icon_001460_256.png", class: "user-icon"
+            %input.input-default{name: "nickname", placeholder: "例)hoge☆セール中", type: "text", value: "hoge"}
+          .setting-profile-content
+            %textarea.textarea-default{name: "introduction", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
+            %input{name: "after_save_callback", type: "hidden", value: "https://www.mercari.com/jp/mypage/profile/"}
+            = button_tag "#", class: "btn-default btn-red", type: "submit" do
+              変更する
+    = render 'mypages/shared/side'
+  = render 'tops/shared/sell-icon'
+  = render 'tops/shared/footer'
+

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -18,15 +18,15 @@
       %section.profile-container
         %h2.profile-container__head
           プロフィール
-        %form{action: "https://www.mercari.com/jp/mypage/profile/", method: "POST"}
-          %input{name: "__csrf_value", type: "hidden", value: "fafebec3310eaf0918dacc38d7d7aad1dc7bfa2e232777baaaf32de3672af8cbf9973e68172a3f137ebfd597393041b81a9bcbb66f6ea631c5d475b99e3e8abac"}
+        %form{action: "#", method: "POST"}
+          %input{name: "__csrf_value", type: "hidden", value: "#"}
           .setting-profile-icon
             %figure
               = image_tag "https://icooon-mono.com/i/icon_00146/icon_001460_256.png", class: "user-icon"
             %input.input-default{name: "nickname", placeholder: "例)hoge☆セール中", type: "text", value: "hoge"}
           .setting-profile-content
             %textarea.textarea-default{name: "introduction", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
-            %input{name: "after_save_callback", type: "hidden", value: "https://www.mercari.com/jp/mypage/profile/"}
+            %input{name: "after_save_callback", type: "hidden", value: "#"}
             = button_tag "#", class: "btn-default btn-red", type: "submit" do
               変更する
     = render 'mypages/shared/side'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,8 @@ Rails.application.routes.draw do
     end
   end
   resources :mypages, only: [:index] do
+    collection do
+      get :profile
+    end
   end
 end


### PR DESCRIPTION
# What
### 1. ルーティング作成
- ひとまずgetメソッドでprofileアクションを設定 
### 2. アクションの定義
- mypages_controller.rbにprofileアクションを定義
### 3. ユーザープロフィール編集画面　haml作成
- header・footerはトップ画面ものをrenderメソッドで読み込んで作成
- side_barはマイページ画面からrenderメソッドで読み込んで作成
### 4. ユーザープロフィール編集画面　scss作成

# Why
ユーザーのプロフィール文を作成できるようにするため。

### 3. 既に作成済みのため

## 補足
- git_ignoreのDS_Storeの記述不足が発覚したため、修正

## 画像

<img width="1440" alt="ユーザープロフィール編集画面１" src="https://user-images.githubusercontent.com/57647938/75050415-4775e300-550f-11ea-9710-de85643009b7.png">

<img width="1440" alt="ユーザープロフィール編集画面２" src="https://user-images.githubusercontent.com/57647938/75050391-3c22b780-550f-11ea-8c6a-d634783d1fed.png">

![ユーザープロフィール編集画面３](https://user-images.githubusercontent.com/57647938/75050347-2614f700-550f-11ea-8a22-7878ba4258e5.jpg)
