### PR TITLE
クレジットカード登録ページのマークアップ　実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import "mypages/identification.scss";
 @import "mypages/profile";
 @import "mypages/card";
+@import "mypages/card_create";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 @import "mypages/shared/side";
 @import "mypages/identification.scss";
 @import "mypages/profile";
+@import "mypages/card";

--- a/app/assets/stylesheets/item_sells/_sell-main.scss
+++ b/app/assets/stylesheets/item_sells/_sell-main.scss
@@ -169,7 +169,7 @@
                 top: 50%;
                 z-index: 2;
                 color: #888;
-                font-size: 25px;
+                font-size: 16px;
                 transform: translate(0, -50%);
               }
             }
@@ -240,7 +240,7 @@
         width: 80%;
         margin: 0 0 0 5%;
 
-      }
+      
         .input-default {
           height: 48px;
           padding: 10px 14px;
@@ -252,6 +252,7 @@
           width: 162px;
           text-align: right;
         }
+      }
 
     .sell-price__form-group__commission {
       padding: 24px 0;
@@ -296,6 +297,10 @@
      transition: all ease-out .3s;
      cursor: pointer;
      text-align: center;
+
+      &:hover {
+        opacity: 0.7;
+      }
    }
 
     .sell-btn-gray {

--- a/app/assets/stylesheets/mypages/card.scss
+++ b/app/assets/stylesheets/mypages/card.scss
@@ -1,0 +1,39 @@
+.card-add__inner {
+  padding: 64px;
+  border-top: 1px solid #f5f5f5;
+
+  .card-add__content {
+    max-width: 320px;
+    margin: 0 auto;
+
+    &__sub-head {
+      font-weight: bold;
+    }
+ }
+   .settings-add-card {
+    padding: 24px 0;
+    border-bottom: 1px solid #eee;
+
+   .card_submit_button {
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      transition: all ease-out .3s;
+      cursor: pointer;
+      text-align: center;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+
+      &:hover {
+      opacity: 0.7;
+     }
+    }
+  }
+   .payment-guide {
+      display: block;
+      margin: 40px 0 0;
+      text-align: right;
+   }
+}

--- a/app/assets/stylesheets/mypages/card_create.scss
+++ b/app/assets/stylesheets/mypages/card_create.scss
@@ -1,0 +1,97 @@
+#add-card-form {
+  padding: 40px 40px 64px;
+  border-top: 1px solid #f5f5f5;
+
+  .card-information__content {
+    max-width: 343px;
+    margin: 0 auto;
+
+    label {
+      font-weight: 600;
+    }
+
+   .input-default {
+     width: 100%;
+     margin: 8px 0 0;
+     height: 48px;
+     padding: 10px 16px 8px;
+     border-radius: 4px;
+     border: 1px solid #ccc;
+     background: #fff;
+     line-height: 1.5;
+     font-size: 16px;
+   }
+
+   .card-list {
+     margin: 8px 0 0;
+     font-size: 0;
+
+     &__icon {
+      width: 45px;
+      height: 20px;
+    }
+   }
+
+   .form-group.expiration-date {
+     margin-top: 32px;
+
+     .select-wrap.half {
+      display: inline-block;
+      width: calc(50% - 2px);
+      margin: 8px 0 0;
+     }
+
+     .select-wrap.half.year {
+       position: absolute;
+       width: 170px;
+     }
+
+      .select-default {
+        width: calc(100% - 38px);
+        position: relative;
+        z-index: 2;
+        height: 48px;
+        padding: 0 16px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: 0;
+        font-size: 16px;
+        line-height: 1.5;
+        cursor: pointer;
+        -webkit-appearance: none;
+      }
+      .icon-arrow-bottom {
+        font-size: 16px;
+        margin: 0 6px 0 -15px;
+        position: relative;
+        top: 3px;
+        pointer-events: none;
+        right: 16px;
+      }
+   }
+   .form-group {
+     margin: 24px 0 0;
+
+     .signup-seqcode {
+       position: relative;
+       margin: 8px 0 0;
+       text-align: right;
+       color: #0099e8;
+
+      .card_submit_button {
+        display: block;
+        margin-top: 32px;
+        background: #ea352d;
+        border: 1px solid #ea352d;
+        color: #fff;
+        width: 100%;
+        line-height: 48px;
+        font-size: 14px;
+        transition: all ease-out .3s;
+        cursor: pointer;
+        text-align: center;
+      }
+     }
+   }
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -12,5 +12,7 @@ class MypagesController < ApplicationController
 
   def card
   end
-  
+
+  def card_create
+  end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -9,4 +9,8 @@ class MypagesController < ApplicationController
 
   def profile
   end
+
+  def card
+  end
+  
 end

--- a/app/views/mypages/card.html.haml
+++ b/app/views/mypages/card.html.haml
@@ -1,0 +1,38 @@
+.wrapper
+  .mypage-header
+    = render 'tops/shared/header'
+  %nav.bread-crumbs
+    %ul
+      %li
+        = link_to root_path do
+          %span フリマアプリ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to mypages_path do
+          %span マイページ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        %span 支払い方法
+  %main.mypage-container.clearfix
+    .mypage-container__right-content
+      %section.profile-container
+        %h2.profile-container__head
+          支払い方法
+        .card-add__inner
+          %section
+            .card-add__content
+              %h3.card-add__content__sub-head
+                クレジットカード一覧
+            %ul.settings-payment-list
+          %section.settings-add-card
+            .card-add__content
+              = link_to "#", class: "card_submit_button" do
+                = icon("fa", "credit-card", class: "card-icon")
+                クレジットカードを追加する
+          .settings-not-regist
+            = link_to "#", class: "payment-guide", taget: "_blank" do
+              %span 支払い方法について
+              = icon('fas', 'angle-right', class: 'mypage-style-right')
+    = render 'mypages/shared/side'
+  = render 'tops/shared/sell-icon'
+  = render 'tops/shared/footer'

--- a/app/views/mypages/card.html.haml
+++ b/app/views/mypages/card.html.haml
@@ -26,7 +26,7 @@
             %ul.settings-payment-list
           %section.settings-add-card
             .card-add__content
-              = link_to "#", class: "card_submit_button" do
+              = link_to card_create_mypages_path, class: "card_submit_button" do
                 = icon("fa", "credit-card", class: "card-icon")
                 クレジットカードを追加する
           .settings-not-regist

--- a/app/views/mypages/card_create.html.haml
+++ b/app/views/mypages/card_create.html.haml
@@ -1,0 +1,95 @@
+.wrapper
+  .mypage-header
+    = render 'tops/shared/header'
+  %nav.bread-crumbs
+    %ul
+      %li
+        = link_to root_path do
+          %span フリマアプリ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to mypages_path do
+          %span マイページ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to card_mypages_path do
+          %span 支払い方法
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        %span クレジットカード情報入力
+  %main.mypage-container.clearfix
+    .mypage-container__right-content
+      %section.profile-container
+        %h2.profile-container__head
+          クレジットカード情報入力
+        %form#add-card-form{action: "#", "data-adyen-id" => "card-form", method: "POST", novalidate: "novalidate"}
+          %input{name: "__csrf_value", type: "hidden", value: "#"}
+            .card-information__content
+              .form-group.card-number
+                %label{for: "payment_card_no"}
+                  カード番号
+                %span.form-require
+                  必須
+                %input#payment_card_number.input-default{"data-input-type" => "card", maxlength: "19", placeholder: "半角数字のみ", type: "text", value: ""}
+                %ul.card-list
+                  %li
+                  = image_tag "#{asset_path "visa.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "master.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "saison-card.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "jcb.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "american_express.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "dinersclub.svg"}", class: 'card-list__icon'
+                  = image_tag "#{asset_path "discover.svg"}", class: 'card-list__icon'
+              .form-group.expiration-date
+                %label{for: "payment_card_expire"}
+                  有効期限
+                %span.form-require
+                  必須
+                %br
+                .select-wrap.half.month
+                  %select#payment_card_expire_month.select-default
+                    %option{value: "01"} 01
+                    %option{value: "02"} 02
+                    %option{value: "03"} 03
+                    %option{value: "04"} 04
+                    %option{value: "05"} 05
+                    %option{value: "06"} 06
+                    %option{value: "07"} 07
+                    %option{value: "08"} 08
+                    %option{value: "09"} 09
+                    %option{value: "10"} 10
+                    %option{value: "11"} 11
+                    %option{value: "12"} 12
+                  = icon('fas', 'chevron-down', class: 'icon-arrow-bottom')
+                  %span 月
+                .select-wrap.half.year
+                  %select#payment_card_expire_year.select-default
+                    %option{value: "20"} 20
+                    %option{value: "21"} 21
+                    %option{value: "22"} 22
+                    %option{value: "23"} 23
+                    %option{value: "24"} 24
+                    %option{value: "25"} 25
+                    %option{value: "26"} 26
+                    %option{value: "27"} 27
+                    %option{value: "28"} 28
+                    %option{value: "29"} 29
+                    %option{value: "30"} 30
+                  = icon('fas', 'chevron-down', class: 'icon-arrow-bottom')
+                  %span 年
+              .form-group.security-code
+                %label{for: "payment_card_security_code"}
+                  セキュリティコード
+                %span.form-require
+                  必須
+                %input#payment_card_security_code.input-default{placeholder: "カード背面4桁もしくは3桁の番号", type: "number", value: ""}
+                .signup-seqcode
+                  .signup-seqcode-text{"data-js" => "show-tips-toggle"}
+                    %span.form-question ?
+                    カード裏面の番号とは？
+                    %br
+                  = link_to card_create_mypages_path do
+                    = button_tag "追加する", class: "card_submit_button"
+    = render 'mypages/shared/side'
+  = render 'tops/shared/sell-icon'
+  = render 'tops/shared/footer'

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -27,8 +27,8 @@
           .setting-profile-content
             %textarea.textarea-default{name: "introduction", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
             %input{name: "after_save_callback", type: "hidden", value: "#"}
-            = button_tag "#", class: "btn-default btn-red", type: "submit" do
-              変更する
+              = link_to profile_mypages_path do
+                = button_tag "変更する", class: "btn-default btn-red", type: "submit"
     = render 'mypages/shared/side'
   = render 'tops/shared/sell-icon'
   = render 'tops/shared/footer'

--- a/app/views/mypages/shared/_side.html.haml
+++ b/app/views/mypages/shared/_side.html.haml
@@ -2,7 +2,7 @@
   %nav.mypage-nav
     %ul.mypage-nav__list
       %li
-        = link_to "#", class: 'mypage-nav__list__item active' do
+        = link_to mypages_path, class: 'mypage-nav__list__item active' do
           マイページ
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
@@ -70,7 +70,7 @@
     %h3.mypage-nav__head 設定
     %ul.mypage-nav__list
       %li
-        = link_to "#", class: 'mypage-nav__list__item' do
+        = link_to profile_mypages_path, class: 'mypage-nav__list__item' do
           プロフィール
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
@@ -78,7 +78,7 @@
           発送元・お届け先住所変更
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
-        = link_to "#", class: 'mypage-nav__list__item' do
+        = link_to card_mypages_path, class: 'mypage-nav__list__item' do
           支払い方法
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       get 'identification'
       get :profile
       get :card
+      get :card_create
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     collection do
       get 'identification'
       get :profile
+      get :card
     end
   end
 end


### PR DESCRIPTION
# What
クレジットカード登録ページとクレジットカード情報入力ページのマークアップを実装した。
(クレジットカード登録後のページは現状、実装予定がない為、作成していない）

## 実装内容
### 1 クレジットカード登録ページのルーティングを追加
- cardアクションをgetメソッドで追加

### 2 mypagesコントローラーにcardアクションを追加

### 3 クレジットカード登録ページのhmlを作成

### 4 クレジットカード登録ページのscssを作成

### 5 マイページサイドバーのリンク先を変更

### 6 クレジットカード情報入力ページのルーティングを追加
- card_createアクションをgetメソッドで追加

### 7 mypagesコントローラーにcard_createアクションを追加
- cardコントローラーを現在作成していない為、createアクションではなく、ひとまずcard_createアクションでビューを表示させる

### 8 クレジットカード情報入力ページのhmlを作成

### 9 クレジットカード情報入力ページのscssを作成
- select-wrap.harf.yearにposition: absolute;とwidth: 170px;をかけることで、横並びにしている

### 10 クレジットカード登録ページの「クレジットカードを追加する」ボタンから情報入力ページに飛ぶようにリンク先を変更

### 11 各ページのリファクタリングを行う

#  Why
ユーザーのクレジットカード情報を登録する為。クレジットカードで商品を購入できるようにする為。

## 補足
- 出品ページのビューに修正箇所があった為、修正
- マイページのプロフィール編集ページの変更ボタンにエラーがあった為、自ページのリンク先を追加することで、エラーを修正

## 画像
- クレジットカード登録ページ

<img width="1440" alt="クレジットカード登録ページ１" src="https://user-images.githubusercontent.com/57647938/75089107-d0852c80-5598-11ea-8990-805ad2516cbb.png">
<img width="1434" alt="クレジットカード登録ページ２" src="https://user-images.githubusercontent.com/57647938/75089110-d3801d00-5598-11ea-9546-ef0caf55a68d.png">
<img width="1440" alt="スクリーンショット 2020-02-22 17 45 52" src="https://user-images.githubusercontent.com/57647938/75089368-4ee2ce00-559b-11ea-9520-a7159d7e1713.png">

- クレジットカード情報入力ページ
<img width="1440" alt="クレジットカード情報入力ページ１" src="https://user-images.githubusercontent.com/57647938/75128538-e9f8b680-5707-11ea-95ca-cd63eb2d2a95.png">
<img width="1440" alt="クレジットカード情報入力ページ２" src="https://user-images.githubusercontent.com/57647938/75128543-eebd6a80-5707-11ea-9572-cd39ef455994.png">
<img width="1440" alt="クレジットカード情報入力ページ３" src="https://user-images.githubusercontent.com/57647938/75128550-f715a580-5707-11ea-97fd-d88b9d463563.png">
