### PR TITLE
ユーザーログアウトページのマークアップ 実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import "mypages/profile";
 @import "mypages/card";
 @import "mypages/card_create";
+@import "mypages/logout";

--- a/app/assets/stylesheets/mypages/logout.scss
+++ b/app/assets/stylesheets/mypages/logout.scss
@@ -1,0 +1,16 @@
+.mypage-container__logout__content {
+  background: #fff;
+
+  .logout_submit_button {
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+    display: block;
+    width: 100%;
+    line-height: 48px;
+    font-size: 14px;
+    transition: all ease-out .3s;
+    cursor: pointer;
+    text-align: center;
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -15,4 +15,7 @@ class MypagesController < ApplicationController
 
   def card_create
   end
+
+  def logout
+  end
 end

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,0 +1,27 @@
+.wrapper
+  .mypage-header
+    = render 'tops/shared/header'
+  %nav.bread-crumbs
+    %ul
+      %li
+        = link_to root_path do
+          %span フリマアプリ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        = link_to mypages_path do
+          %span マイページ
+        = icon('fas', 'angle-right', class: 'mypage-style-right')
+      %li
+        %span ログアウト
+  %main.mypage-container.clearfix
+    .mypage-container__right-content
+      .mypage-container__logout
+        .mypage-container__logout__content
+          %form.card-add__inner{action: "#", method: "POST", novalidate: "novalidate"}
+            .card-add__content
+              = link_to root_path do
+                = button_tag "ログアウト", class: "logout_submit_button", type: "submit"
+              %input{name: "__csrf_value", type: "hidden", value: "#"}
+    = render 'mypages/shared/side'
+  = render 'tops/shared/sell-icon'
+  = render 'tops/shared/footer'

--- a/app/views/mypages/shared/_side.html.haml
+++ b/app/views/mypages/shared/_side.html.haml
@@ -94,6 +94,6 @@
           電話番号の確認
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
-        = link_to "#", class: 'mypage-nav__list__item' do
+        = link_to logout_mypages_path, class: 'mypage-nav__list__item' do
           ログアウト
           = icon('fas', 'angle-right', class: 'mypage-style-right')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       get :profile
       get :card
       get :card_create
+      get :logout
     end
   end
 end


### PR DESCRIPTION
# What
- ユーザーログアウトページのマークアップの実装をした。

## 実装内容

### 1 ルーティングの設定
- getメソッドで「logout」アクションを追加

### 2 mypgesコントローラーに「logout」アクションを定義

### 3 ユーザーログアウトページのhamlを作成
- card.html.hamlと同じCSSが当たっている箇所は、同じクラス名で作成

### 4 ユーザーログアウトページのscssを作成
- 上記の工程を行うことで、card.scssのCSSを一部当てている

### 5 「ログアウト」ボタンを押すと、トップページに飛ぶようにリンク先を設定

### 6 マイページサイドバーの「ログアウト」のリンク先をログアウトページに飛ぶようにリンク先を変更

# Why
ユーザーがログアウトできるようにするため。

## 実装内容

### 1 マイページの中のページのため、ひとまず、　resources mypagesの中でルーティングを設定している

### 4 同じCSSの記述を減らすため

##  画像
<img width="1440" alt="ユーザーログアウトページ１" src="https://user-images.githubusercontent.com/57647938/75216435-5bec0100-57d7-11ea-8343-b195c08e3df8.png">
<img width="1440" alt="ユーザーログアウトページ２" src="https://user-images.githubusercontent.com/57647938/75216809-986c2c80-57d8-11ea-976a-6928d0476c86.png">
<img width="1440" alt="ユーザーログアウトページ３" src="https://user-images.githubusercontent.com/57647938/75216821-9efaa400-57d8-11ea-8d6f-1d6d24234ef8.png">

