### PR TITLE
デプロイ前修正2-1

### DIFF
--- a/app/views/mypages/card_create.html.haml
+++ b/app/views/mypages/card_create.html.haml
@@ -82,7 +82,7 @@
                   セキュリティコード
                 %span.form-require
                   必須
-                %input#payment_card_security_code.input-default{placeholder: "カード背面4桁もしくは3桁の番号", type: "number", value: ""}
+                %input#payment_card_security_code.input-default{placeholder: "カード背面4桁もしくは3桁の番号", type: "text", value: ""}
                 .signup-seqcode
                   .signup-seqcode-text{"data-js" => "show-tips-toggle"}
                     %span.form-question ?

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -13,6 +13,6 @@
             = icon('fab', 'facebook-square')
             Facebookで登録する
           = button_tag '', class: 'contents__btn contents__btn__google' do
-            = image_tag '/assets/g_rainbow.png', class: 'contents__btn__google__icon-google', size: '30x30'
+            = image_tag "#{asset_path "g_rainbow.png"}", class: 'contents__btn__google__icon-google', size: '30x30'
             Googleで登録する
   = render 'item_sells/footer'

--- a/app/views/users/login.html.haml
+++ b/app/views/users/login.html.haml
@@ -12,7 +12,7 @@
           = icon('fab', 'facebook-square')
           Facebookでログイン
         = button_tag '', class: 'contents__btn contents__btn__google' do
-          = image_tag '/assets/g_rainbow.png', class: 'contents__btn__google__icon-google', size: '30x30'
+          = image_tag "#{asset_path "g_rainbow.png"}", class: 'contents__btn__google__icon-google', size: '30x30'
           Googleで登録する
       %form{action: "", method: "", novalidate: "novalidate"}
         .login-form-inner


### PR DESCRIPTION
# What
自動デプロイ後ビュー崩れを見つけたため、再度修正ブランチを作成した。　

## 修正内容
### 1.クレジットカード登録ページ
・inputタグのタイプをnumberから→textへ変更。サーバサイド実装時、半角数字しか入力できないようバリデーションを設定する。
### 2.新規登録,ログインページ
・image_tagの画像参照先をasset_parthへ変更。

# Why
スプリントレビュー前に見た目を整えたいため。
## 修正内容
### 1.クレジットカード登録ページ
・numberだとフォームの右側にボタンが表示されるため。
### 2.新規登録,ログインページ
・グーグルアイコン画像が本番環境で表示できなかったため。