### PR TITLE
パンくずリストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ gem 'haml-rails'
 gem 'font-awesome-sass'
 gem 'pry-rails'
 gem 'active_hash'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -299,6 +301,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -42,3 +42,22 @@ body {
   font-size: 12px;
   vertical-align: top;
   }
+
+.breadcrumbs {
+
+  & i {
+  margin: 0 8px;
+  font-size: 9px;
+  color: #888;
+  }
+
+  & .breadcrumbs-current {
+  font-weight: 600;
+
+  }
+
+  & a {
+  color: #333;
+  touch-action: manipulation;
+  }
+}

--- a/app/assets/stylesheets/mypages/index.scss
+++ b/app/assets/stylesheets/mypages/index.scss
@@ -1,4 +1,4 @@
-.bread-crumbs {
+.bread-crumbs-list {
   position: relative;
   border-bottom: 1px solid rgba(0,0,0,0.16);
   background: #fff;
@@ -14,21 +14,6 @@
       display: inline-block;
       font-size: 14px;
       line-height: 1.2;
-
-      &:last-child {
-        font-weight: 600;
-      }
-
-      & a {
-        color: #333;
-        touch-action: manipulation;
-      }
-
-      & .mypage-style-right {
-        margin: 0 8px;
-        font-size: 9px;
-        color: #888;
-      }
     }
   }
 }

--- a/app/views/mypages/card.html.haml
+++ b/app/views/mypages/card.html.haml
@@ -1,18 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to mypages_path do
-          %span マイページ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span 支払い方法
+        - breadcrumb :card
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       %section.profile-container

--- a/app/views/mypages/card_create.html.haml
+++ b/app/views/mypages/card_create.html.haml
@@ -1,22 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to mypages_path do
-          %span マイページ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to card_mypages_path do
-          %span 支払い方法
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span クレジットカード情報入力
+        - breadcrumb :card_create
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       %section.profile-container

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,18 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to mypages_path do
-          %span マイページ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span 本人情報の登録
+        - breadcrumb :identification
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       %section.mypage-identification

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,14 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span マイページ
+        - breadcrumb :mypages
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       %section.mypage-user-icon

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,18 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to mypages_path do
-          %span マイページ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span ログアウト
+        - breadcrumb :logout
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       .mypage-container__logout

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,18 +1,11 @@
 .wrapper
   .mypage-header
     = render 'shared/header'
-  %nav.bread-crumbs
+  %nav.bread-crumbs-list
     %ul
       %li
-        = link_to root_path do
-          %span フリマアプリ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to root_path do
-          %span マイページ
-        = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        %span プロフィール
+        - breadcrumb :profile
+        = breadcrumbs separator: "#{content_tag(:i, '', class: 'fas fa-angle-right')}", current_class: "breadcrumbs-current"
   %main.mypage-container.clearfix
     .mypage-container__right-content
       %section.profile-container

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,32 @@
+crumb :root do
+  link "フリマアプリ", root_path
+end
+
+crumb :mypages do
+  link "マイページ", mypages_path
+end
+
+crumb :profile do
+  link "プロフィール", profile_mypages_path
+  parent :mypages
+end
+
+crumb :card do
+  link "支払い方法", card_mypages_path
+  parent :mypages
+end
+
+crumb :card_create do
+  link "クレジットカード情報入力", card_create_mypages_path
+  parent :card
+end
+
+crumb :identification do
+  link "本人情報の登録", identification_mypages_path
+  parent :mypages
+end
+
+crumb :logout do
+  link "ログアウト", logout_mypages_path
+  parent :mypages
+end


### PR DESCRIPTION
# What
gem「gretel」を使用し、パンくずリストを実装した。現状作成したパンくずリストは、viewを作成した以下の画像の箇所のみ作成。

## 実装内容

### 1 gem「gretel」を導入
### 2 breadcrmbs.rb の作成
- パンくずリストのルーティングとリンク先を設定
- parentメソッドでパンくずリストの親のルーティングを追加
### 3 現在作成済みのパンくずリストhamlの記述を全て変更
1.  bread-crmbsのdivタグのクラス名を「bread-crumbs-list」に変更
2.  「breadcrumb :リンク先のpath」でリンク先を追加
3.  content_tagを使用することで、
- fontawesomeのアイコンの使用
- iタグの追加
   をしている
4. パンくずリストの現在地である太字の部分は、クラス名「breadcrmbs-current」で設定

以上4点をパンくずリストを作成した全てのhamlに記述している
### 4 パンくずリストのCSSを追加
- 全てのパンくずリストに共通でCSSを当てるために、_common.scssに記述
### 5 不要なCSSの削除
- hamlの記述変更に伴い、今までmypages.scssで当てていたCSSで不要になった部分を削除

# Why
パンくずリストを作成することでユーザーが今いるページの現在地を分かりやすくするため。
その結果、サイトの利便性が上がるため。
また、既存のコードより、コードの記述量が少なくて済むため。

## 実装内容
### 3 
1. 今回の記述変更に伴い、「breadcrmbs」というdivタグが自動生成されるため、分かりやすく区別するためにクラス名を変更した。
3. 「aタグ」「 >」「パンくずリストの現在地」それぞれに個別のCSSを当てるため。
4. クラス名を設定することで記述位置や当たっているCSSを分かりやすくするため。

## 画像
<img width="1440" alt="マイページパンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623116-80d2e080-5bea-11ea-8411-d691cdea4b56.png">
<img width="1440" alt="プロフィールパンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623137-a6f88080-5bea-11ea-8b59-3dc9b5e4fc60.png">
<img width="1440" alt="支払い方法パンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623140-ac55cb00-5bea-11ea-85cc-c198cb6f1582.png">
<img width="1440" alt="クレジットカード情報入力パンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623144-baa3e700-5bea-11ea-90fa-2e79a85b67a9.png">
<img width="1440" alt="本人情報の登録パンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623149-c4c5e580-5bea-11ea-90c8-7d26a6b711f4.png">
<img width="1440" alt="ログアウトパンくずリスト" src="https://user-images.githubusercontent.com/57647938/75623152-ca233000-5bea-11ea-9435-930e9c1c2a53.png">

