### PR TITLE
[Fix] ユーザー登録関連ページエラー修正＋form関連で使用するCSSのmixinファイル作成

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -34,14 +34,8 @@ body {
 }
 
 .form-require {
-  background: #ea352d;
-  margin: 0 0 0 8px;
-  padding: 2px 4px;
-  border-radius: 2px;
-  color: #fff;
-  font-size: 12px;
-  vertical-align: top;
-  }
+  @include form-require;
+}
 
 .breadcrumbs {
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "font-awesome";
 @import "config/reset";
 @import "config/color";
+@import "config/mixin/form";
 @import "config/mixin/new-account-header-definition";
 @import "config/mixin/sin-up-definition";
 @import "config/mixin/inner";

--- a/app/assets/stylesheets/config/mixin/_form.scss
+++ b/app/assets/stylesheets/config/mixin/_form.scss
@@ -1,0 +1,19 @@
+@mixin form-require() {
+  background: #ea352d;
+  margin: 0 0 0 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+@mixin form-arbitrary() {
+  background: #ccc;
+  margin-bottom: 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+}

--- a/app/assets/stylesheets/mypages/identification.scss
+++ b/app/assets/stylesheets/mypages/identification.scss
@@ -38,13 +38,7 @@
       }
 
       & .form-arbitrary {
-        background: #ccc;
-        margin-bottom: 8px;
-        padding: 2px 4px;
-        border-radius: 2px;
-        color: #fff;
-        font-size: 12px;
-        vertical-align: top;
+        @include form-arbitrary;
       }
 
       & .input-default {

--- a/app/views/users/address.html.haml
+++ b/app/views/users/address.html.haml
@@ -62,4 +62,4 @@
             = link_to credit_users_path do
               = button_tag '#', class: 'single-main__container__registration-form__content__input-box__btn', type: 'submit' do
                 次へ進む
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -78,4 +78,4 @@
             = link_to done_users_path do
               = button_tag '#', class: 'single-main__container__registration-form__content__input-box__btn', type: 'submit' do
                 次へ進む
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'

--- a/app/views/users/done.html.haml
+++ b/app/views/users/done.html.haml
@@ -14,4 +14,4 @@
             = link_to mypages_path do
               = button_tag '#', class: 'single-main__container__registration-form__content__input-box__btn', type: 'submit' do
                 Fmarketをはじめる
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,5 @@
 .wrapper
-  = render 'item_sells/header'
+  =render 'shared/sell-header'
   %main.single-main
     %section.single-main__container
       %h2.single-main__container__header
@@ -15,4 +15,4 @@
           = button_tag '', class: 'contents__btn contents__btn__google' do
             = image_tag "#{asset_path "g_rainbow.png"}", class: 'contents__btn__google__icon-google', size: '30x30'
             Googleで登録する
-  = render 'item_sells/footer'
+  = render 'shared/sell-footer'

--- a/app/views/users/login.html.haml
+++ b/app/views/users/login.html.haml
@@ -1,5 +1,5 @@
 .wrapper
-  = render 'item_sells/header'
+  =render 'shared/sell-header'
   %main.single-main
     .single-main__login-panel
       .single-main__login-panel__no-account
@@ -25,4 +25,4 @@
               ログイン
           .login-form-inner__form-group
             = link_to "パスワードをお忘れの方", '#', class: "find-password"
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -250,4 +250,4 @@
                 and
                 = link_to "Terms of Service" "", class: "single-main__container__registration-form__content__input-box__recaptcha-term__text"
                 apply.
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'

--- a/app/views/users/tel.html.haml
+++ b/app/views/users/tel.html.haml
@@ -24,4 +24,4 @@
                     = icon('fas', 'chevron-right', class: 'single-main__container__registration-form__content__input-box__text-right__icon')
                 %input{name: "__csrf_value", type: "hidden", value: ""}
                 %input{name: "id", type: "hidden", value: ""}
-  = render 'item_sells/footer'
+  =render 'shared/sell-footer'


### PR DESCRIPTION
# What
1. ユーザー登録関連のページを読み込む際に、renderでファイルが読み込めないエラーが出ていたため、修正
2. 「必須」「任意」のmixinファイル設定


# Why
1. item関連をまとめる際に、renderで読み込んでいたheaderとfooterのファイル名が変更されたが、user登録関連のページで修正がされていなかったため。
2. 多くのページで使用しているため。記述量を減らすため。

## 画像
<img width="1440" alt="スクリーンショット 2020-03-02 14 59 21" src="https://user-images.githubusercontent.com/57647938/75649585-f5fbef80-5c96-11ea-93a2-9378c5d42985.png">
<img width="1440" alt="スクリーンショット 2020-03-02 14 59 30" src="https://user-images.githubusercontent.com/57647938/75649590-f8f6e000-5c96-11ea-8b2b-48675185aa6b.png">
<img width="1440" alt="スクリーンショット 2020-03-02 14 59 44" src="https://user-images.githubusercontent.com/57647938/75649592-fa280d00-5c96-11ea-95ef-bc04f46f3d53.png">
<img width="1440" alt="スクリーンショット 2020-03-02 15 01 36" src="https://user-images.githubusercontent.com/57647938/75649593-fac0a380-5c96-11ea-8026-e5376b406c47.png">
<img width="1440" alt="スクリーンショット 2020-03-02 15 02 20" src="https://user-images.githubusercontent.com/57647938/75649594-fac0a380-5c96-11ea-9505-e248ab71f962.png">
<img width="1440" alt="スクリーンショット 2020-03-02 15 02 28" src="https://user-images.githubusercontent.com/57647938/75649597-fb593a00-5c96-11ea-93fa-35a51d26f97e.png">
<img width="1440" alt="スクリーンショット 2020-03-02 15 02 32" src="https://user-images.githubusercontent.com/57647938/75649598-fbf1d080-5c96-11ea-90ef-57d384421bdd.png">
<img width="1440" alt="スクリーンショット 2020-03-02 15 02 38" src="https://user-images.githubusercontent.com/57647938/75649599-fc8a6700-5c96-11ea-8b99-027e658be4af.png">
