### PR TITLE
Add to/addressesテーブルのカラム追加

### DIFF
--- a/db/migrate/20200310053618_rename_prefecture_id_column_to_addresses.rb
+++ b/db/migrate/20200310053618_rename_prefecture_id_column_to_addresses.rb
@@ -1,4 +1,5 @@
 class RenamePrefectureIdColumnToAddresses < ActiveRecord::Migration[5.2]
   def change
+    rename_column :addresses, :prefecture_id, :prefecture
   end
 end

--- a/db/migrate/20200310053618_rename_prefecture_id_column_to_addresses.rb
+++ b/db/migrate/20200310053618_rename_prefecture_id_column_to_addresses.rb
@@ -1,0 +1,4 @@
+class RenamePrefectureIdColumnToAddresses < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/migrate/20200310062808_add_rate_to_addresses.rb
+++ b/db/migrate/20200310062808_add_rate_to_addresses.rb
@@ -1,4 +1,12 @@
 class AddRateToAddresses < ActiveRecord::Migration[5.2]
   def change
+    add_reference :addresses, :user, foreign_key: true
+    add_column :addresses, :family_name,      :string, null: false
+    add_column :addresses, :first_name,       :string, null: false
+    add_column :addresses, :family_name_kana, :string, null: false
+    add_column :addresses, :first_name_kana,  :string, null: false
+    add_column :addresses, :zip_code,         :string, null:false
+    add_column :addresses, :adress,           :string, null: false
+    add_column :addresses, :building,         :string
   end
 end

--- a/db/migrate/20200310062808_add_rate_to_addresses.rb
+++ b/db/migrate/20200310062808_add_rate_to_addresses.rb
@@ -1,0 +1,4 @@
+class AddRateToAddresses < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/migrate/20200310072517_drop_city_to_addresses.rb
+++ b/db/migrate/20200310072517_drop_city_to_addresses.rb
@@ -1,0 +1,4 @@
+class DropCityToAddresses < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/migrate/20200310072517_drop_city_to_addresses.rb
+++ b/db/migrate/20200310072517_drop_city_to_addresses.rb
@@ -1,4 +1,5 @@
 class DropCityToAddresses < ActiveRecord::Migration[5.2]
   def change
+    remove_column :addresses, :city, :string
   end
 end

--- a/db/migrate/20200310073607_add_city_to_addresses.rb
+++ b/db/migrate/20200310073607_add_city_to_addresses.rb
@@ -1,4 +1,5 @@
 class AddCityToAddresses < ActiveRecord::Migration[5.2]
   def change
+    add_column :addresses, :city, :string, null: false
   end
 end

--- a/db/migrate/20200310073607_add_city_to_addresses.rb
+++ b/db/migrate/20200310073607_add_city_to_addresses.rb
@@ -1,0 +1,4 @@
+class AddCityToAddresses < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_062808) do
+ActiveRecord::Schema.define(version: 2020_03_10_072517) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture"
-    t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_072517) do
+ActiveRecord::Schema.define(version: 2020_03_10_073607) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_03_10_072517) do
     t.string "zip_code", null: false
     t.string "adress", null: false
     t.string "building"
+    t.string "city", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_120839) do
+ActiveRecord::Schema.define(version: 2020_03_10_053618) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "prefecture_id"
+    t.integer "prefecture"
     t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_053618) do
+ActiveRecord::Schema.define(version: 2020_03_10_062808) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture"
     t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.string "zip_code", null: false
+    t.string "adress", null: false
+    t.string "building"
+    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -41,4 +50,5 @@ ActiveRecord::Schema.define(version: 2020_03_10_053618) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "addresses", "users"
 end


### PR DESCRIPTION
# What
#### 1
addressesテーブルに必要なカラムを追加
#### 2
cityカラムにオプションがついていなかった為、一度cityカラムを削除し、改めてオプションをつけて追加した
#### 3
「prefecture_id」カラムの名前を「prefecture」に変更

# Why
active hashを利用する際にaddressesテーブルを作成したが、必要なカラムを全ては作成していなかったため、整理した。