### PR TITLE
商品削除機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'capistrano3-unicorn'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.4.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -353,6 +357,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/javascripts/delete.js
+++ b/app/assets/javascripts/delete.js
@@ -1,0 +1,8 @@
+$(function(){
+  $('.btn-delete').click(function(){
+    var alert = "確認\n削除すると２度と復活できません。\n削除する代わりに停止することもできます。\n本当に削除しますか？"
+    if(!confirm(alert)){
+      return false;
+    }
+  });
+});

--- a/app/assets/javascripts/delete.js
+++ b/app/assets/javascripts/delete.js
@@ -1,5 +1,7 @@
-$(function(){
+$(document).on('turbolinks:load', function(){
+
   $('.btn-delete').click(function(){
+    console.log('hoge')
     var alert = "確認\n削除すると２度と復活できません。\n削除する代わりに停止することもできます。\n本当に削除しますか？"
     if(!confirm(alert)){
       return false;

--- a/app/assets/javascripts/delete.js
+++ b/app/assets/javascripts/delete.js
@@ -1,7 +1,6 @@
 $(document).on('turbolinks:load', function(){
 
   $('.btn-delete').click(function(){
-    console.log('hoge')
     var alert = "確認\n削除すると２度と復活できません。\n削除する代わりに停止することもできます。\n本当に削除しますか？"
     if(!confirm(alert)){
       return false;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -20,36 +20,55 @@ $(document).on('turbolinks:load', function(){
 
     // ラベルのwidth操作
     function setLabel() {
+      //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
+      //.label-contentを対象として後に続けて直前のHTML要素(prev-content)をprev()で取得。変数prevContentとして使用
       var prevContent = $('.label-content').prev();
+      //全体のwidth620から選択した画像枚数分のwidthを引く。
+      //prevContentから.label-contentのwidthの数値から半角数字のみを全て検索して文字列に置換
       labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
       $('.label-content').css('width', labelWidth);
     }
 
     // プレビューの追加
     $(document).on('change', '.hidden-field', function(){
+      // 画像選択ボタンの値が変化したときラベルのwidthを変化させる
       setLabel();
+      //hidden-fieldの数値のみ取得
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
+      //labelボックスのidとforを更新
+      //(attrでlabel-boxのidを取得。更新？)
       $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
+      //選択された画像情報を取得
       var file = this.files[0];
+      //FileReaderオブジェクトをインスタンス化
       var reader = new FileReader();
+      //readAsDataURLで指定したFileオブジェクトを読み込む
       reader.readAsDataURL(file);
+      //読み込み時に発火するイベント
       reader.onload = function() {
         var image = this.result;
+        // プレビューが元々なかった場合はhtmlを追加
         if ($(`#preview-box__${id}`).length == 0) {
+          // preview-boxの要素の数をcountに入れる
           var count = $('.preview-box').length;
+          //プレビューのhtmlを変数htmlに入れる
           var html = buildHTML(id);
+          //ラベルの直前のプレビュー群にプレビュー画像を追加
           var prevContent = $('.label-content').prev();
           $(prevContent).append(html);
         }
         //イメージを追加
         $(`#preview-box__${id} img`).attr('src', `${image}`);
         var count = $('.preview-box').length;
+        //プレビューが5個あったらラベルを隠す
         if (count == 5) {
           $('.label-content').hide();
         }
 
         setLabel();
+        //ラベルのidとforの値を変更
         if(count < 5){
+          //プレビューの数でラベルのオプションを更新する
           $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_image`});
         }
       }
@@ -59,11 +78,15 @@ $(document).on('turbolinks:load', function(){
     $(document).on('click', '.delete-box', function(){
       var count = $('.preview-box').length;
       setLabel(count);
+      //item_images_attributes_${id}_image から${id}に入った数字のみを抽出
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
+      //取得したidに該当するプレビューを削除
       $(`#preview-box__${id}`).remove();
+      //フォームの中身を削除
       $(`#item_images_attributes_${id}_image`).val("");
-
+      //削除時のラベル操作
       var count = $('.preview-box').length;
+      //5個目が消されたらラベルを表示
       if (count == 4) {
         $('.label-content').show();
       }
@@ -71,6 +94,7 @@ $(document).on('turbolinks:load', function(){
       setLabel(count);
 
       if(id < 5){
+        //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする 
         $('.label-box').attr({id: `label-box--${id}`, for: `item_images_attributes_${id}_image`});
       }
     });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "config/mixin/new-account-header-definition";
 @import "config/mixin/sin-up-definition";
 @import "config/mixin/inner";
+@import "config/mixin/btn.gray";
 @import "common";
 @import "items/index.scss";
 @import "items/new.scss";

--- a/app/assets/stylesheets/config/mixin/_btn.gray.scss
+++ b/app/assets/stylesheets/config/mixin/_btn.gray.scss
@@ -1,0 +1,15 @@
+@mixin btn-gray() {
+  background: #aaa;
+  border: 1px solid #aaa;
+  color: #fff;
+  display: block;
+  width: 100%;
+  line-height: 48px;
+  font-size: 14px;
+  border: 1px solid transparent;
+  -webkit-transition: all ease-out .3s;
+  transition: all ease-out .3s;
+  cursor: pointer;
+  text-align: center;
+  margin: 10px 0;
+}

--- a/app/assets/stylesheets/items/show_mine.scss
+++ b/app/assets/stylesheets/items/show_mine.scss
@@ -31,19 +31,10 @@
 }
 
 .btn-gray {
-  background: #aaa;
-  border: 1px solid #aaa;
-  color: #fff;
-  display: block;
-  width: 100%;
-  line-height: 48px;
-  font-size: 14px;
-  border: 1px solid transparent;
-  -webkit-transition: all ease-out .3s;
-  transition: all ease-out .3s;
-  cursor: pointer;
-  text-align: center;
-  margin: 10px 0;
+  @include btn-gray;
+}
+.btn-delete {
+  @include btn-gray;
 }
 
 .btn-gray-disabled {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -62,8 +62,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user_id == current_user.id
-      @item.destroy
+    if @item.destroy
       redirect_to listing_users_path
     else
       render :show_mine

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :show_mine, :item_stop, :item_state, :item_buy, :confirmation]
+  before_action :set_item, only: [:show, :show_mine, :item_stop, :item_state, :item_buy, :confirmation, :destroy]
 
   def index
     @items = Item.all
@@ -59,6 +59,15 @@ class ItemsController < ApplicationController
   end
 
   def complete
+  end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to listing_users_path
+    else
+      render :show_mine
+    end
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  has_many :images, dependent: :destroy
+  has_many :images, dependent: :delete_all
   belongs_to :user, required: true
   # accepts_nested_attributes_for→　fields_forメソッドを利用する際に、親モデルの中に書く必要があるメソッド。引数として子モデルの名前を記述。
   # allow_destroy→　親のレコードが削除された場合に、関連付いている子のレコードも一緒に削除される。

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  has_many :images
+  has_many :images, dependent: :destroy
   belongs_to :user, required: true
   # accepts_nested_attributes_for→　fields_forメソッドを利用する際に、親モデルの中に書く必要があるメソッド。引数として子モデルの名前を記述。
   # allow_destroy→　親のレコードが削除された場合に、関連付いている子のレコードも一緒に削除される。

--- a/app/views/items/show_mine.html.haml
+++ b/app/views/items/show_mine.html.haml
@@ -92,7 +92,9 @@
       - else @item.sales_status == "公開停止"
         = link_to item_state_items_path(@item.id) do
           .btn-red 出品を再開する
-      %button.btn-gray{"data-modal" => "delete-item", "data-open" => "modal"} この商品を削除する
+      .btn-delete
+        =link_to item_path, class:"btn-gray",method: :delete do
+          この商品を削除する
   .item-detail-message
     .item-detail-message__container
       .item-detail-message__container__content

--- a/app/views/items/show_mine.html.haml
+++ b/app/views/items/show_mine.html.haml
@@ -92,9 +92,8 @@
       - else @item.sales_status == "公開停止"
         = link_to item_state_items_path(@item.id) do
           .btn-red 出品を再開する
-      .btn-delete
-        =link_to item_path, class:"btn-gray",method: :delete do
-          この商品を削除する
+      =link_to item_path, class:"btn-delete",method: :delete do
+        この商品を削除する
   .item-detail-message
     .item-detail-message__container
       .item-detail-message__container__content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get 'completed'
     end
   end
-  resources :items, only: [:index, :new, :create, :show] do
+  resources :items, only: [:index, :new, :create, :show, :destroy] do
   end
   resource :items, only: :confirmation, path: ":id" do
     collection do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe ItemsController, type: :controller  do
+  let(:user) { create(:user) }
+
+  describe 'GET #destroy' do
+    it "【商品削除】インスタンス変数の値が期待したものになるか" do
+      item = create(:item)
+      delete :destroy, params: { id: item }
+      expect(assigns(:item)).to eq item
+    end
+  end
+end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :image do
-    image {File.open("#{Rails.root}/public/uploads/image/image/3/Ruby_on_Rails5の上手な使い方.jpg")}
+    image {File.open("#{Rails.root}/public/uploads/image/image/7/Ruby_on_Rails5の上手な使い方.jpg")}
     association :item
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -17,5 +17,6 @@ FactoryBot.define do
     images {[
       FactoryBot.build(:image, item: nil)  #itemと同時にimage作成
     ]}
+    user
   end
 end


### PR DESCRIPTION
# What
商品削除機能を実装した。

## 実装内容(削除機能)
### １．itemsコントローラーにdestroyアクションを追加
### ２．routes.rbにdestroyアクションを追加
### ３．出品商品画面の削除ボタンのパスを変更。
・itemsコントローラーのdestroyアクションに遷移するように変更。
### ４．mixinファイル追加
・グレーボタンのcssを追加(おそらく反映時application.scssでコンフリクトが起こります)
### ５．delete.js作成
・削除ボタンを押した時に再確認させるメッセージを表示させる

## 実装内容(単体テスト)
### １．gem 'rails-controller-testing'を追加
### ２．items_controller_spec.rbファイル作成
・リクエストされたdestroyアクションの中で定義されている@itemが、間違いないかをテスト。
### ３．(factories/items.rb)修正
・「user」を追加
### ４．(factories/images.rb)修正
・現在「取引中」のitemのimage idに変更(「/public/uploads/image/image/**7**/・・・"」)

# Why
削除機能がないと商品が購入されない限り出品した商品情報が残るため。

## 実装内容(削除機能)
### ５．delete.js作成
・誤操作で商品を削除するのを防ぐため。

## 実装内容(単体テスト)
### １．gem 'rails-controller-testing'を追加
・コントローラーのテストを行えるようにするため。
### ３．(factories/items.rb)修正
・userとのアソシエーションが組まれていなかったため。
### ４．(factories/images.rb)修正
・「/public/uploads/image/image/3/・・・"」のitemを削除してしまったため。

↓商品削除(GIF)
https://i.gyazo.com/c7f31d14c38db561fd1ad26f1f7faee7.gif