### PR TITLE
gem activesupport導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,4 @@ gem 'active_hash'
 gem "gretel"
 gem 'jquery-rails'
 gem 'devise'
+gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  activesupport
   bootsnap (>= 1.1.0)
   byebug
   capistrano

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,8 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @images = @item.images
+    @image = @images.first
   end
 
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,7 @@
+require 'active_support/core_ext/numeric/conversions'
 module ItemsHelper
+
+  def converting_to_mark(price)
+    "¥ #{@item.price.to_s(:delimited)}"
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -85,7 +85,8 @@
             %th 発送日の目安
             %td 2~3日で発送
     .item-price-box
-      %span.item-price-box__bold ¥35,800
+      %span.item-price-box__bold 
+        = converting_to_mark("#{@item.price}")
       %span.item-price-box__tax (税込)
       %span.item-price-box__fee 送料込み
     .text-center

--- a/db/migrate/20200317050104_change_datatype_price_of_items.rb
+++ b/db/migrate/20200317050104_change_datatype_price_of_items.rb
@@ -1,0 +1,9 @@
+class ChangeDatatypePriceOfItems < ActiveRecord::Migration[5.2]
+  def up
+    change_column :items, :price, :integer
+  end
+
+  def down
+    change_column :items, :price, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_100340) do
+ActiveRecord::Schema.define(version: 2020_03_17_050104) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_100340) do
     t.string "name", null: false
     t.text "text", null: false
     t.integer "condition", null: false
-    t.string "price", null: false
+    t.integer "price", null: false
     t.integer "fee_burden", null: false
     t.integer "service", null: false
     t.integer "area", null: false


### PR DESCRIPTION
# What
gem activesupportを導入した。

## 実装内容
### １．gemfile編集
・gem 'activesupport'を導入
### ２．Itemsテーブルpriceカラム型変更
・**string型→integer型**に変更。ロールバック検証済み。
　（各作業ブランチでマイグレーションファイルを編集されている場合はコンフリクト対応が必要になります）
### ３．show.html.haml編集
・converting_to_mark(price)でitems_heperの処理に飛ぶように変更。
### ４．items_helper.rb編集
・ビューから受け取った関数「converting_to_mark(price)」に関する処理を記述。


# Why
Itemsテーブルのpriceカラムの値を表示する際、数値のみの表示となるため。