### PR TITLE
add/gemのcapybaraを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'faker', "~> 2.8"
+  gem 'capybara', '>= 2.15'
 end
 
 group :development do


### PR DESCRIPTION
# What
gemのcapybaraをGemfileの、
「group :development, :test do」部に記述、bundle installを実行し、導入した。

# Why
テスト時に使用する為。