### PR TITLE
Fix/トップページの商品価格の修正

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -54,8 +54,7 @@
                     %span.category-groups__content__items__item__title
                   .category-groups__content__items__item__description
                     %span{class: 'item-price'}
-                      ¥
-                      = item.price
+                      = "¥ #{item.price.to_s(:delimited)}"
                     = image_tag "#{item.images[0].image_url}", class: 'show-image', alt: "画像が表示できません"
   = render 'shared/sell-icon'
   =render 'shared/footer'

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -25,7 +25,7 @@ describe ItemsController, type: :controller  do
 end
 
 describe 'GET #new' do
-    it "renders the :new template" do
+    it "newアクションでnew.html.hamlに遷移するようになっているか？" do
       get :new
       expect(response).to render_template :new
     end


### PR DESCRIPTION
# What
1.  トップページに表示させた商品の価格を３桁区切り(,)で表示するように修正
2. item.controllerのnewアクションテストの説明を日本語に変更

# Why
1.  商品詳細の価格表示と同じにさせるため
2. 他のテストの説明と合わせるため。また、日本語の方がわかりやすいため。

# 画像
<img width="1440" alt="スクリーンショット 2020-03-18 13 32 29" src="https://user-images.githubusercontent.com/57647938/76925548-32794d80-691d-11ea-904b-5c23258d0695.png">
