### PR TITLE
商品編集機能実装

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -18,6 +18,29 @@ $(document).on('turbolinks:load', function(){
       return html;
     }
 
+    // 投稿編集時
+    //items/:i/editページへリンクした際のアクション＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝
+    if (window.location.href.match(/\/items\/\d+\/edit/)){
+      //登録済み画像のプレビュー表示欄の要素を取得する
+      var prevContent = $('.label-content').prev();
+      labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+      $('.label-content').css('width', labelWidth);
+      //プレビューにidを追加
+      $('.preview-box').each(function(index, box){
+        $(box).attr('id', `preview-box__${index}`);
+      })
+      //削除ボタンにidを追加
+      $('.delete-box').each(function(index, box){
+        $(box).attr('id', `delete_btn_${index}`);
+      })
+      var count = $('.previeww-box').length;
+      //プレビューが5あるときは、投稿ボックスを消して奥
+      if (count == 5) {
+        $('.label-content').hide();
+      }
+    }
+    //=======================================================================================
+
     // ラベルのwidth操作
     function setLabel() {
       //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
@@ -65,6 +88,12 @@ $(document).on('turbolinks:load', function(){
           $('.label-content').hide();
         }
 
+        //プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す==========
+        if ($(`#item_images_attributes_${id}__destroy`)){
+          $(`#item_images_attributes_${id}__destroy`).prop('checked',false);
+        }
+        //==================================================================================
+
         setLabel();
         //ラベルのidとforの値を変更
         if(count < 5){
@@ -82,21 +111,43 @@ $(document).on('turbolinks:load', function(){
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
       //取得したidに該当するプレビューを削除
       $(`#preview-box__${id}`).remove();
-      //フォームの中身を削除
-      $(`#item_images_attributes_${id}_image`).val("");
-      //削除時のラベル操作
-      var count = $('.preview-box').length;
-      //5個目が消されたらラベルを表示
-      if (count == 4) {
-        $('.label-content').show();
-      }
 
-      setLabel(count);
+      //新規登録時と編集時の場合分け============================================================
 
-      if(id < 5){
-        //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする 
-        $('.label-box').attr({id: `label-box--${id}`, for: `item_images_attributes_${id}_image`});
+      //新規投稿時
+      //削除用チェックボックスの有無で判定
+      if ($(`#item_images_attributes_${id}__destroy`).length == 0) {      //追加
+        //フォームの中身を削除
+        $(`#item_images_attributes_${id}_image`).val("");
+        //削除時のラベル操作
+        var count = $('.preview-box').length;
+        //5個目が消されたらラベルを表示
+        if (count == 4) {
+          $('.label-content').show();
+        }
+        setLabel(count);
+        if(id < 5){
+          //削除された際に、空っぽになったfile_fieldをもう一度入力可能にする 
+          $('.label-box').attr({id: `label-box--${id}`, for: `item_images_attributes_${id}_image`});
+        }
+      } else {
+
+        //投稿編集時
+        $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
+        //5個目が消されたらラベルを表示
+        if (count == 4) {
+          $('.label-content').show();
+        }
+
+        //ラベルのwidth操作
+        setLabel();
+        //ラベルのidとforの値を変更
+        //削除したプレビューのidによって、ラベルのidを変更する
+        if(id < 5){
+          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_image`});
+        }
       }
+      //==================================================================================
     });
   });
 })

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :show_mine, :item_stop, :item_state, :item_buy, :confirmation, :destroy]
+  before_action :set_item, only: [:show, :show_mine, :item_stop, :item_state, :item_buy, :confirmation, :destroy, :edit, :update]
 
   def index
     @items = Item.where(sales_status:"1").order("created_at DESC").limit(10)
@@ -74,6 +74,17 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @item.update(update_item_params)
+      redirect_to listing_users_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params
@@ -81,7 +92,7 @@ class ItemsController < ApplicationController
   end
 
   def update_item_params
-    params.require(:item).permit(:name, :text, :condition, :price, :fee_burden, :service, :area, :handing_time, :category, :sales_status, [images_attributes: [:image]]).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :condition, :price, :fee_burden, :service, :area, :handing_time, :category, :sales_status, [images_attributes: [:image, :_destroy, :id]]).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -79,7 +79,7 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(update_item_params)
-      redirect_to listing_users_path
+      redirect_to show_mine_items_path(@item)
     else
       render :edit
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   validates :name, length: { in: 1..40 }, presence: true
   validates :text, length: { in: 1..1000 }, presence: true
   validates :condition, presence: true
-  validates :price, presence: true
+  validates :price, presence: true, numericality: { only_integer: true,greater_than: 299, less_than: 10000000}
   validates :fee_burden, presence: true
   validates :service, presence: true
   validates :area, presence: true

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -31,8 +31,8 @@
                       .delete-box
                         .delete-btn
                           %span 削除
+                          
               .label-content
-
                 //プレビューの数に合わせてforオプションを指定
                 = f.label :"images_attributes_#{@item.images.length}_image", class:"label-box", id: "label-box--#{@item.images.length}" do
                   %pre.label-box__text-visible クリックしてファイルをアップロード
@@ -42,7 +42,7 @@
                   =i.file_field :image, class: "hidden-field"
                   =i.check_box:_destroy, class: "hidden-checkbox"
 
-                  //5つのfile_fieldを準備するに当たって、足りない分を表示
+                  //5つのfile_fieldを準備するに当たって、足りない分を表示(元々保存していた数しか追加削除できないのを解消)
                 - @item.images.length.upto(4) do |i|
                   %input{name: "item[images_attributes][#{i}][image]", id: "item_images_attributes_#{i}_image", class: "hidden-field", type:"file"}
           .sell-form__container__item
@@ -156,6 +156,6 @@
                 = link_to "加盟店規約", "#", class: "sell-form__content__sell-btn-box__rule__link"
                 に同意したことになります。
             = f.submit "変更する", class:"sell-btn-red",id:"item_botton"
-            = link_to "もどる", root_path, class: "sell-btn-gray"
+            = link_to "もどる", show_mine_items_path(@item), class: "sell-btn-gray"
 
   =render 'shared/sell-footer'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,161 @@
+.wrapper
+  =render 'shared/sell-header'
+
+  %main.sell-main
+    %section.sell-main-container
+      .sell-main__container__inner
+        %h2.sell-main__container__head
+          商品の情報を入力
+        = form_with model:@item, local:true do |f|
+          - if @item.errors.any?
+            %h2= "#{@item.errors.full_messages.count}件のエラーが発生しました。"
+            %ul
+              - @item.errors.full_messages.each do |message|
+                %li= message
+          =f.hidden_field :sales_status,{value: "出品中"}
+          .sell-form__image__upload__box
+            %h3.sell-form__image__upload__box__head
+              出品画像
+              %span.form-require
+                必須
+            %p
+              最大5枚までアップロードできます
+            .sell-form__post__drop__box__container
+              .prev-content
+                //JSで挿入したhtmlと同じ形　each文でのプレビュー表示
+                - @item.images.each do |image|
+                  .preview-box
+                    .upper-box
+                      = image_tag image.image.url, width: "112", height: "112", alt: "preview"
+                    .lower-box
+                      .delete-box
+                        .delete-btn
+                          %span 削除
+              .label-content
+
+                //プレビューの数に合わせてforオプションを指定
+                = f.label :"images_attributes_#{@item.images.length}_image", class:"label-box", id: "label-box--#{@item.images.length}" do
+                  %pre.label-box__text-visible クリックしてファイルをアップロード
+              .hidden-content
+                =f.fields_for :images do |i|
+                  //プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
+                  =i.file_field :image, class: "hidden-field"
+                  =i.check_box:_destroy, class: "hidden-checkbox"
+
+                  //5つのfile_fieldを準備するに当たって、足りない分を表示
+                - @item.images.length.upto(4) do |i|
+                  %input{name: "item[images_attributes][#{i}][image]", id: "item_images_attributes_#{i}_image", class: "hidden-field", type:"file"}
+          .sell-form__container__item
+            .sell-form__container__item__name
+              %label
+                商品名
+                %span.form-require
+                  必須
+              %div
+                = f.text_field :name, id: "input-default", placeholder: "商品名（必須 40文字まで)", class: "sell-form__container__item__default"
+            .sell-form__container__item__description
+              %label
+                商品の説明
+                %span.form-require
+                  必須
+              = f.text_area :text,  class: "sell-form__container__item__description__default", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "5"
+          .sell-form__content__details
+            %h3.sell-form__content__head
+              商品の詳細
+            .sell-form__content__box
+              .sell-form__content__group
+                %label
+                  カテゴリー
+                  %span.form-require
+                    必須
+                %div
+                  .sell-form__select__wrap
+                    = icon('fas', 'angle-down', class: 'angele-down')
+                    = f.select :category, Item.categories.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+              .sell-form__content__group__lower
+                %label
+                  商品の状態
+                  %span.form-require
+                    必須
+                .sell-form__select__wrap
+                  = icon('fas', 'angle-down', class: 'angele-down')
+                  = f.select :condition, Item.conditions.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+          .sell-form__content__delivery
+            %h3.sell-form__content__head
+              配送について
+            = link_to "?", "#", class: "form-question"
+            .sell-form__content__box
+              .sell-form__content__group
+                %label
+                  配送料の負担
+                  %span.form-require
+                    必須
+                .sell-form__select__wrap
+                  = icon('fas', 'angle-down', class: 'angele-down')
+                  = f.select :fee_burden, Item.fee_burdens.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+                %label
+                  配送の方法
+                  %span.form-require
+                    必須
+                .sell-form__select__wrap
+                  = icon('fas', 'angle-down', class: 'angele-down')
+                  = f.select :service, Item.services.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+              .sell-form__content__group__lower
+                %label
+                  発送元の地域
+                  %span.form-require
+                    必須
+                .sell-form__select__wrap
+                  = icon('fas', 'angle-down', class: 'angele-down')
+                  = f.select :area, Item.areas.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+              .sell-form__content__group__lower
+                %label
+                  発送までの日数
+                  %span.form-require
+                    必須
+                .sell-form__select__wrap
+                  = icon('fas', 'angle-down', class: 'angele-down')
+                  = f.select :handing_time, Item.handing_times.keys,{prompt: '---'}, class: 'sell-form__select__wrap__default'
+          .sell-form__content__price
+            %h3.sell-form__content__head
+              販売価格(300〜9,999,999)
+            = link_to "?", "#", class: "form-question"
+            .sell-form__content__box
+              %ul.sell-price
+                %li.sell-price__form-group
+                  .sell-price__form-group__clearfix
+                    %label.sell-price__form-group__clearfix__left
+                      価格
+                      %span.form-require
+                        必須
+                    .sell-price__en
+                      ¥
+                      .sell-price__input
+                        = f.text_field :price, min:300, max:9999999, class: "input-default", id: "sell-price", placeholder: "例）300", value: @item.price
+                %li.sell-price__form-group__commission
+                  .sales-profit
+                    販売手数料 (10%)
+                  .l-right -
+                %li.clearfix.bold
+                  .left
+                    販売利益
+                  .l-right -
+          .sell-form__content__sell-btn-box
+            %div
+              %p.sell-form__content__sell-btn-box__rule
+                = link_to "禁止されている出品", "#", class: "sell-form__content__sell-btn-box__rule__link"
+                、
+                = link_to "行為", "#", class: "sell-form__content__sell-btn-box__rule__link"
+                を必ずご確認ください。
+              %p.sell-form__content__sell-btn-box__rule
+                またブランド品でシリアルナンバー等がある場合はご記載ください。
+                = link_to "偽ブランドの販売", "#", class: "sell-form__content__sell-btn-box__rule__link"
+                は犯罪であり処罰される可能性があります。
+              %p.sell-form__content__sell-btn-box__rule
+                また、出品をもちまして
+                = link_to "加盟店規約", "#", class: "sell-form__content__sell-btn-box__rule__link"
+                に同意したことになります。
+            = f.submit "変更する", class:"sell-btn-red",id:"item_botton"
+            = link_to "もどる", root_path, class: "sell-btn-gray"
+
+  =render 'shared/sell-footer'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -22,7 +22,6 @@
               最大5枚までアップロードできます
             .sell-form__post__drop__box__container
               .prev-content
-                //JSで挿入したhtmlと同じ形　each文でのプレビュー表示
                 - @item.images.each do |image|
                   .preview-box
                     .upper-box
@@ -33,16 +32,13 @@
                           %span 削除
                           
               .label-content
-                //プレビューの数に合わせてforオプションを指定
                 = f.label :"images_attributes_#{@item.images.length}_image", class:"label-box", id: "label-box--#{@item.images.length}" do
                   %pre.label-box__text-visible クリックしてファイルをアップロード
               .hidden-content
                 =f.fields_for :images do |i|
-                  //プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
                   =i.file_field :image, class: "hidden-field"
                   =i.check_box:_destroy, class: "hidden-checkbox"
 
-                  //5つのfile_fieldを準備するに当たって、足りない分を表示(元々保存していた数しか追加削除できないのを解消)
                 - @item.images.length.upto(4) do |i|
                   %input{name: "item[images_attributes][#{i}][image]", id: "item_images_attributes_#{i}_image", class: "hidden-field", type:"file"}
           .sell-form__container__item

--- a/app/views/items/show_mine.html.haml
+++ b/app/views/items/show_mine.html.haml
@@ -73,7 +73,7 @@
         = @item.text
   .show-mine__bottom-container
     .show-mine__bottom-container__change-box
-      = link_to "商品の編集", root_path, class: "btn-red"
+      = link_to "商品の編集", edit_item_path(@item.id), class: "btn-red"
       %p.text-center or
       - if @item.sales_status == "出品中"
         = link_to item_stop_items_path(@item.id) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get 'completed'
     end
   end
-  resources :items, only: [:index, :new, :create, :show, :destroy] do
+  resources :items, only: [:index, :new, :create, :show, :destroy, :edit] do
   end
   resource :items, only: :confirmation, path: ":id" do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get 'completed'
     end
   end
-  resources :items, only: [:index, :new, :create, :show, :destroy, :edit] do
+  resources :items, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
   end
   resource :items, only: :confirmation, path: ":id" do
     collection do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -57,4 +57,17 @@ describe ItemsController, type: :controller  do
     end
   end
 
+  describe 'GET #edit' do
+    it "【編集ページ】インスタンス変数の値が期待したものになるか" do
+      item = create(:item)
+      get :edit, params: { id: item}
+      expect(assigns(:item)).to eq item
+    end
+    it "編集ページへ遷移するか" do
+      item = create(:item)
+      get :edit, params: {id: item}
+      expect(response).to render_template :edit
+    end
+  end
+
 end


### PR DESCRIPTION
# What
商品編集機能を実装した。
jsファイルのコメントアウトは後で見返せるように残した。
## 実装内容(編集機能)
### １．ルーティング追加
・edit,updateを追加

### ２．コントローラー追加
・edit,updateアクションを追加

### ３．ビューファイル(edit.html.haml)作成
画像と金額の記述を変更。
#### 【金額】
 ・「value: @item.price」とする事で編集ページに遷移した際、すでに保存されている金額を表示。
#### 【画像】
・編集ページに遷移した際、すでに保存されている画像のプレビューを表示したいため、
　each文で画像を取得して、JSで挿入したhtmlと同じ形で記述。
・プレビューの数に合わせてforオプションを指定。
・プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置。
・5つのfile_fieldを準備するに当たって、足りない分を表示(元々保存していた画像枚数しか追加削除
　できないのを解消。）

### ４．jsファイル(items.js)編集
・出品ページの画像のプレビュー表示に編集時の記述を追加。流れについては以下のとおり。
　(1) id = 0, 1のfile_fieldが投稿済の状態でプレビュー表示されている。
　(2)id = 0の削除ボタンを押す。
　(3)プレビューが削除されるとともに、id = 0のfile_fieldに対応する削除用チェックボックスに
　   チェックが入る。
　(4) labelをクリックすると削除済みのid = 0のfile_fieldが空になり、再度保存できるようになる。
　(5)再度id = 0に新しい画像が入ったら、削除用チェックボックスのチェックを外す。

## 実装内容(単体テスト)
以下の内容についてテストを実施。
・インスタンス変数の値が期待したものになるか
・編集ページへ遷移するか

# Why
・商品情報の一部を変更したい場合、削除→再度出品するのは手間がかかるため。

↓商品編集機能GIF
https://i.gyazo.com/f29793ed806550c787cfad12682bdc87.gif