### PR TITLE
デプロイ前修正 [Viewとエラー]

### DIFF
--- a/app/assets/stylesheets/mypages/shared/_side.scss
+++ b/app/assets/stylesheets/mypages/shared/_side.scss
@@ -25,8 +25,9 @@
         color: #333;
 
         &.active {
-          background: #eee;
-          font-weight: 600;
+          // マイページサイドバー選択した際のCSS
+          // background: #eee;
+          // font-weight: 600;
 
           & .mypage-style-right {
             color: #333;

--- a/app/assets/stylesheets/mypages/shared/_side.scss
+++ b/app/assets/stylesheets/mypages/shared/_side.scss
@@ -30,7 +30,7 @@
           // font-weight: 600;
 
           & .mypage-style-right {
-            color: #333;
+            // color: #333;
           }
         }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to mypages_path
     else
+      @item.images.new
       @category_parents = Category.where(ancestry: nil).map{|i| [i.category, i.id]}
       render :new
     end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -29,7 +29,7 @@
 
                 =f.password_field :password, placeholder: "7文字以上の半角英数字", required: 'true', class: "single-main__container__registration-form__content__input-box__default"
                 %p.form-info-text
-                  ※ 英字と数字の両方を含めて設定してください
+                  ※ 英字か数字で設定してください
               .single-main__container__registration-form__content__input-box
                 = f.label :パスワード確認
                 %span.single-main__container__registration-form__content__input-box__require

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -10,7 +10,8 @@
     .mypage-container__right-content
       %section.mypage-identification
         %h2.mypage-identification__head 本人情報の登録
-        %form.mypage-identification__right-single-inner{action: "#", method: "POST", novalidate: ""}
+        // method: "POST"のままだと、エラーが出るため、仮のリンク先に変更
+        %form.mypage-identification__right-single-inner{action: "#", method: "#", novalidate: ""}
           %div
             %p
               お客さまの本人情報をご登録ください。

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -33,7 +33,7 @@
           .form-group
             %label{for: "zip_code"} 郵便番号
             %span.form-arbitrary 任意
-            %input.input-default{name: "zip_code", placeholder: "例）1234567", type: "text", value: ""}
+            %input.input-default{name: "zip_code", placeholder: "例）1234567", type: "text", value: "", maxlength: "7"}
           .form-group
             %label{for: "zip_code"} 都道府県
             %span.form-arbitrary 任意


### PR DESCRIPTION
# What
以下の修正を行なった。

### 1. 本人確認情報ページで「登録」ボタンを押すとエラーが出るため、修正
- 仮のリンク先を設定

### 2. 新規会員登録のパスワード登録の案内表示を修正

###  3. マイページサイドバー選択した際のCSS解除

# Why
### 1.エラーページはなるべく出ないようにしたいため。

### 2. 現状、英字・数字両方入れなくても、登録できるため。

### 3. 機能未実装のため。