### PR TITLE
ビュー修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,6 @@
 class MypagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user, only: [:index, :identification, :profile]
 
   def index
   end
@@ -17,5 +19,11 @@ class MypagesController < ApplicationController
   end
 
   def logout
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:listing, :in_progress, :completed, :purchased]
 
   def index
   end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -57,5 +57,8 @@
                     %span{class: 'item-price'}
                       = "¥ #{item.price.to_s(:delimited)}"
                     = image_tag "#{item.images[0].image_url}", class: 'show-image', alt: "画像が表示できません"
+                      -if item.sales_status == "売却済み" || item.sales_status == "取引中"
+                      .items_box_photo_sold
+                        .items_box_photo_sold__inner SOLD
   = render 'shared/sell-icon'
   =render 'shared/footer'

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -23,13 +23,16 @@
                 = icon('fas', 'angle-right', class: 'mypage-style-right')
           .form-group
             %label お名前
-            %p hoge
+            %p 
+              = @user.family_name
           .form-group
             %label お名前カナ
-            %p hoge
+            %p 
+              = @user.first_name
           .form-group
             %label{for: "birthday"} 生年月日
-            %p 2000/01/01
+            %p 
+              = "#{@user.birth_year}/#{@user.birth_month}/#{@user.birth_day}"
           .form-group
             %label{for: "zip_code"} 郵便番号
             %span.form-arbitrary 任意

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -12,7 +12,8 @@
         = link_to "#" do
           %figure
             = image_tag "https://icooon-mono.com/i/icon_00146/icon_001460_256.png"
-          %h2 hoge
+          %h2 
+            = @user.nickname
           .mypage-number
             %div
               評価

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -16,7 +16,7 @@
           .setting-profile-icon
             %figure
               = image_tag "https://icooon-mono.com/i/icon_00146/icon_001460_256.png", class: "user-icon"
-            %input.input-default{name: "nickname", placeholder: "例)hoge☆セール中", type: "text", value: "hoge"}
+            %input.input-default{name: "nickname", placeholder: "例)hoge☆セール中", type: "text", value: @user.nickname}
           .setting-profile-content
             %textarea.textarea-default{name: "introduction", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
             %input{name: "after_save_callback", type: "hidden", value: "#"}


### PR DESCRIPTION
# What
ビューの表示方法とauthenticate_user!の処理を追加した。

## 実装内容
１．mypage関連のビューへはログインしていない状態では遷移できないように設定。
２．出品状態・購入状態の確認ページも同様にログインしていない状態では遷移できないように設定した。
３．ユーザー関連の情報をマイページ,プロフィール,本人確認ページで表示。
４．トップページの売却済み商品に「SOLD」ラベルを追加。

# Why
・ビューの見た目を良くするため。
・ログインしていない状態直接パスを指定して遷移するとエラーが出るため。